### PR TITLE
Decreases the main window minimum height to 500px

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,7 +25,7 @@ MainWindow::MainWindow(QWidget *parent)
     setWindowTitle(QApplication::applicationName());
     setWindowIcon(QIcon(":/icons/app/icon-256.png"));
     setMinimumWidth(800);
-    setMinimumHeight(600);
+    setMinimumHeight(500);
 
     restoreGeometry(settings.value("geometry").toByteArray());
     restoreState(settings.value("windowState").toByteArray());


### PR DESCRIPTION
After some testing with WhatsApp Web, 500px seems to be a good value for the minimum height.