### PR TITLE
feat: enable support for traybar entries on GNOME dash

### DIFF
--- a/dist/linux/com.ktechpit.whatsie.desktop
+++ b/dist/linux/com.ktechpit.whatsie.desktop
@@ -15,7 +15,12 @@ StartupNotify=true
 MimeType=x-scheme-handler/whatsapp;
 X-GNOME-UsesNotifications=true
 
-Actions=Settings;Lock;About;
+Actions=Chat;Settings;Lock;About;
+
+[Desktop Action Chat]
+Name[it]=Nuova Chat
+Name=New Chat
+Exec=whatsie -n
 
 [Desktop Action Settings]
 Name[it]=Impostazioni

--- a/dist/linux/com.ktechpit.whatsie.desktop
+++ b/dist/linux/com.ktechpit.whatsie.desktop
@@ -1,15 +1,33 @@
 [Desktop Entry]
-Version=1.0
-GenericName=Qt Whatsapp Web Client
-Name[en_US]=WhatSie
-Comment=Qt WhatsApp Web Client 
 Name=WhatSie
-Type=Application
+GenericName[it]=Client Qt per WhatsApp Web
+GenericName=Qt WhatsApp Web Client
+Comment[it]=Un Client per WhatsApp Web basato su QT
+Comment=A WhatsApp Web Client using the QT framework
 Icon=com.ktechpit.whatsie
-StartupWMClass=whatsie
-Keywords=WhatSie;WhatsApp
 Exec=whatsie %u
-Categories=Chat;Network;InstantMessaging;Qt;
-MimeType=x-scheme-handler/whatsapp;
 Terminal=false
+Type=Application
+Categories=Chat;Network;InstantMessaging;Qt;
+Keywords=WhatSie;WhatsApp;
+StartupWMClass=whatsie
+StartupNotify=true
+MimeType=x-scheme-handler/whatsapp;
 X-GNOME-UsesNotifications=true
+
+Actions=Settings;Lock;About;
+
+[Desktop Action Settings]
+Name[it]=Impostazioni
+Name=Settings
+Exec=whatsie -s
+
+[Desktop Action Lock]
+Name[it]=Blocca
+Name=Lock
+Exec=whatsie -l
+
+[Desktop Action About]
+Name[it]=Info
+Name=About
+Exec=whatsie -i


### PR DESCRIPTION
Using GNOME environment and having traybar usage deprecated (no traybar at all to make it simple), makes me hard and non-intuitive to open the advanced custom settings (I only discovered it after some screenshot of yours XD). Instead of reinventing the wheel I managed to put some new entries within the dash icon.
a screenshot is more than thousand words
![image](https://user-images.githubusercontent.com/491117/175507372-e576da55-9de3-4dd5-8788-ecf1526b7e7c.png)
where 'Impostazioni' stands for settings in Italian.

if you like it, the only missing stuff (on code side), should be the `-s` (flags) for the whatsie command to open the settings window