### PR TITLE
fix: hide/show window only when tray icon is left clicked

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1110,7 +1110,7 @@ void MainWindow::handleDownloadRequested(QWebEngineDownloadItem *download) {
 
 void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
   Q_UNUSED(reason);
-  if (settings.value("minimizeOnTrayIconClick", false).toBool() == false)
+  if (settings.value("minimizeOnTrayIconClick", false).toBool() == false || reason == QSystemTrayIcon::Context)
     return;
   if (isVisible()) {
     hide();


### PR DESCRIPTION
fix: #47 The window maintains its state when the tray icon context menu is opened and `Show/Hide on click tray Icon (if supported)` option is checked