### PR TITLE
Use qmake-provided _DATE_

### DIFF
--- a/src/WhatsApp.pro
+++ b/src/WhatsApp.pro
@@ -50,7 +50,7 @@ CONFIG(debug, debug|release) {
 # Define git info
 GIT_HASH="\\\"$$system(git -C \""$$_PRO_FILE_PWD_"\" rev-parse --short HEAD)\\\""
 GIT_BRANCH="\\\"$$system(git -C \""$$_PRO_FILE_PWD_"\" rev-parse --abbrev-ref HEAD)\\\""
-BUILD_TIMESTAMP="\\\"$$system(date -u +\""%Y-%m-%dT%H:%M:%SUTC\"")\\\""
+BUILD_TIMESTAMP="\"\\\"$${_DATE_}\\\"\""
 DEFINES += GIT_HASH=$$GIT_HASH GIT_BRANCH=$$GIT_BRANCH BUILD_TIMESTAMP=$$BUILD_TIMESTAMP
 
 # Set program version


### PR DESCRIPTION
Use qmake-provided `_DATE_`

This allows for reproducible builds with
https://codereview.qt-project.org/c/qt/qtbase/+/494174

Note that this changes the date format, so does not work if some
automated parsers rely on ISO8601 format.

Alternatives are:
* drop `BUILD_TIMESTAMP`
* use `date -r $somepath/CHANGELOG.md`
* use [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) to allow overriding date

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).