### PR TITLE
Fix incorrect full width modification

### DIFF
--- a/src/webenginepage.cpp
+++ b/src/webenginepage.cpp
@@ -348,7 +348,7 @@ void WebEnginePage::injectClassChangeObserver() {
       R"(
         const observer = new MutationObserver(() => {
             var haveFullView = document.body.classList.contains('whatsie-full-view');
-            var container = document.querySelector('#app > .app-wrapper-web > div');
+            var container = document.querySelector('#app > .app-wrapper-web > .two');
             if(container){
                 if(haveFullView){
                     container.style.width = '100%';
@@ -404,7 +404,7 @@ void WebEnginePage::injectFullWidthJavaScript() {
     return;
   QString js =
       R"(function updateFullWidthView(element) {
-            var container = document.querySelector('#app > .app-wrapper-web > div');
+            var container = document.querySelector('#app > .app-wrapper-web > .two');
             container.style.width = '100%';
             container.style.height = '100%';
             container.style.top = '0';


### PR DESCRIPTION
The current version of WhatsApp Web appears to have changed the element structure within the `app` and `app-wrapper-web` containers. This prevents the full-width fix from working correctly, since the `app-wrapper-web` container now contains two div elements, the second of which (which has class `two`) needs to be selected in order for the full-width functionality to be restored.