### PR TITLE
Add support for secure compilation flags on aarch64 (specific) and generic

### DIFF
--- a/src/WhatsApp.pro
+++ b/src/WhatsApp.pro
@@ -4,6 +4,10 @@
 #
 #-------------------------------------------------
 
+QMAKE_CXXFLAGS = $$QMAKE_CXXFLAGS $$(CXXFLAGS)
+QMAKE_CFLAGS = $$QMAKE_CFLAGS $$(CFLAGS)
+QMAKE_LFLAGS = $$QMAKE_LDFLAGS $$(LDFLAGS)
+
 QT += core gui webengine webenginewidgets positioning
 
 CONFIG += c++17

--- a/src/WhatsApp.pro
+++ b/src/WhatsApp.pro
@@ -4,9 +4,9 @@
 #
 #-------------------------------------------------
 
-QMAKE_CXXFLAGS = $$QMAKE_CXXFLAGS $$(CXXFLAGS)
-QMAKE_CFLAGS = $$QMAKE_CFLAGS $$(CFLAGS)
-QMAKE_LFLAGS = $$QMAKE_LDFLAGS $$(LDFLAGS)
+QMAKE_CFLAGS = $$QMAKE_CFLAGS -fstack-protector-strong -fstack-clash-protection -mbranch-protection=standard -D_FORTIFY_SOURCE=3 -D_GLIBCXX_ASSERTIONS
+QMAKE_CXXFLAGS = $$QMAKE_CFLAGS
+#QMAKE_LFLAGS = $$QMAKE_LDFLAGS $$(LDFLAGS)
 
 QT += core gui webengine webenginewidgets positioning
 


### PR DESCRIPTION
Hi,

I would like to have those secure flags by default on the main repo because they improve the security of the binary procuded by the compilation process.

This pull request only gives support to ROP protection with the -mbranch-protection flag on aarch64, but specifying -fcf-protection can enable it for x86_64.

I don't know how to make a platform dependant compilation flags switching, but maybe you encounter this pull request interesting and know how to do it well.


Best regards.