### PR TITLE
fix: fix spell checker

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,8 @@ int main(int argc, char *argv[]) {
   QApplication::setOrganizationName("org.keshavnrj.ubuntu");
   QApplication::setApplicationVersion(VERSIONSTR);
 
+ qputenv("QTWEBENGINE_DICTIONARIES_PATH",Dictionaries::GetDictionaryPath().toUtf8().constData());  
+
   QCommandLineParser parser;
   parser.setApplicationDescription(
       QObject::tr("Feature rich WhatsApp web client based on Qt WebEngine"));


### PR DESCRIPTION
Whatsie resolves the dictionaries path at runtime, but Qt WebEngine has [its own way](https://doc.qt.io/qt-5/qtwebengine-features.html#spellchecker) to resolve the dictionaries path using `QTWEBENGINE_DICTIONARIES_PATH`.

> If `QTWEBENGINE_DICTIONARIES_PATH` is set, the spellchecker uses the dictionaries in the specified directory without looking anywere else. Otherwise, it uses the *qtwebengine_dictionaries* directory relative to the executable if it exists. If it does not exist, it will look in `QT_INSTALL_PREFIX/qtwebengine_dictionaries`.

This might lead to Qt WebEngine not finding dictionaries or having different dictionaries than Whatsie.

An example would be if Whatsie found the right path and Qt WebEngine did not; the dictionaries would show in settings, but the spell checker would not work, as described in #78 and #79.

To avoid that scenario, this PR sets `QTWEBENGINE_DICTIONARIES_PATH` to the path resolved by [dictionaries.cpp](https://github.com/keshavbhatt/whatsie/blob/3ad375a1bca7b76ab18a9da109d761049d006326/src/dictionaries.cpp#L17C1-L54C2).

So, this PR should fix #78 and fix #79.

#156 and the comments in 90210de might be related to the `QTWEBENGINE_DICTIONARIES_PATH` env var being set at the system level to a wrong or empty directory.