### PR TITLE
Add Qt 6 support

### DIFF
--- a/src/WhatsApp.pro
+++ b/src/WhatsApp.pro
@@ -23,7 +23,9 @@ equals(QMAKE_HOST.arch, aarch64) {
 # Uncomment if you need specific linker flags as well
 #QMAKE_LFLAGS += $$QMAKE_LDFLAGS
 
-QT += core gui webengine webenginewidgets positioning
+QT += core gui webenginewidgets positioning
+
+lessThan(QT_MAJOR_VERSION, 6): QT += webengine
 
 CONFIG += c++17
 

--- a/src/automatictheme.cpp
+++ b/src/automatictheme.cpp
@@ -47,7 +47,11 @@ AutomaticTheme::AutomaticTheme(QWidget *parent)
                 ui->refresh->setEnabled(false);
               }
             });
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    connect(m_gPosInfoSrc, &QGeoPositionInfoSource::errorOccurred, this, [=]() {
+#else
     connect(m_gPosInfoSrc, &QGeoPositionInfoSource::updateTimeout, this, [=]() {
+#endif
       if (!SettingsManager::instance().settings().value("sunrise").isValid() ||
           !SettingsManager::instance().settings().value("sunset").isValid()) {
         if (ui->refresh->isEnabled())

--- a/src/automatictheme.cpp
+++ b/src/automatictheme.cpp
@@ -81,9 +81,9 @@ void AutomaticTheme::on_refresh_clicked() {
   if (geoCor.isValid()) {
     Sunclock sun(this->m_latitube, this->m_longitude, this->m_hourOffset);
     m_sunrise.setSecsSinceEpoch(
-        sun.sunrise(QDateTime::currentDateTimeUtc().toTime_t()));
+        sun.sunrise(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()));
     m_sunset.setSecsSinceEpoch(
-        sun.sunset(QDateTime::currentDateTimeUtc().toTime_t()));
+        sun.sunset(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()));
 
     ui->sunrise->setTime(m_sunrise.time());
     ui->sunset->setTime(m_sunset.time());

--- a/src/downloadmanagerwidget.h
+++ b/src/downloadmanagerwidget.h
@@ -57,12 +57,14 @@
 
 #include <QFileDialog>
 #include <QStandardPaths>
-#include <QWebEngineDownloadItem>
 #include <QWidget>
 
-QT_BEGIN_NAMESPACE
-class QWebEngineDownloadItem;
-QT_END_NAMESPACE
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QWebEngineDownloadRequest>
+using QWebEngineDownloadItem = QWebEngineDownloadRequest;
+#else
+#include <QWebEngineDownloadItem>
+#endif
 
 class DownloadWidget;
 

--- a/src/downloadwidget.cpp
+++ b/src/downloadwidget.cpp
@@ -4,7 +4,6 @@
 #include <QDesktopServices>
 #include <QFileInfo>
 #include <QUrl>
-#include <QWebEngineDownloadItem>
 
 DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download,
                                QWidget *parent)
@@ -38,8 +37,15 @@ DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download,
       emit removeClicked(this);
   });
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  connect(m_download, &QWebEngineDownloadItem::receivedBytesChanged, this,
+          &DownloadWidget::updateWidget);
+  connect(m_download, &QWebEngineDownloadItem::totalBytesChanged, this,
+          &DownloadWidget::updateWidget);
+#else
   connect(m_download, &QWebEngineDownloadItem::downloadProgress, this,
           &DownloadWidget::updateWidget);
+#endif
 
   connect(m_download, &QWebEngineDownloadItem::stateChanged, this,
           &DownloadWidget::updateWidget);

--- a/src/downloadwidget.h
+++ b/src/downloadwidget.h
@@ -58,9 +58,12 @@
 #include <QFrame>
 #include <QTime>
 
-QT_BEGIN_NAMESPACE
-class QWebEngineDownloadItem;
-QT_END_NAMESPACE
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QWebEngineDownloadRequest>
+using QWebEngineDownloadItem = QWebEngineDownloadRequest;
+#else
+#include <QWebEngineDownloadItem>
+#endif
 
 // Displays one ongoing or finished download (QWebEngineDownloadItem).
 class DownloadWidget final : public QFrame, public Ui::DownloadWidget {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,13 @@
 #include <QDebug>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
-#include <QtWebEngine>
 #include <QtWidgets>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtWebEngineCore>
+#else
+#include <QtWebEngine>
+#endif
 
 #include "common.h"
 #include "def.h"
@@ -136,12 +141,10 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  QWebEngineSettings::defaultSettings()->setAttribute(
-      QWebEngineSettings::DnsPrefetchEnabled, true);
-  QWebEngineSettings::defaultSettings()->setAttribute(
-      QWebEngineSettings::FullScreenSupportEnabled, true);
-  QWebEngineSettings::defaultSettings()->setAttribute(
-      QWebEngineSettings::JavascriptCanAccessClipboard, true);
+  QWebEngineSettings *websettings = QWebEngineProfile::defaultProfile()->settings();
+  websettings->setAttribute(QWebEngineSettings::DnsPrefetchEnabled, true);
+  websettings->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);
+  websettings->setAttribute(QWebEngineSettings::JavascriptCanAccessClipboard, true);
 
   MainWindow whatsie;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,9 @@
 
 int main(int argc, char *argv[]) {
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
 
 #ifdef QT_DEBUG
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -156,7 +156,7 @@ int main(int argc, char *argv[]) {
         qInfo().noquote() << "Another instance with PID: " +
                                  QString::number(instanceId) +
                                  ", sent argument: " + message;
-        QString messageStr = QTextCodec::codecForMib(106)->toUnicode(message);
+        QString messageStr = QString::fromUtf8(message);
 
         QCommandLineParser p;
         p.addOptions(secondaryInstanceCLIOptions);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -43,7 +43,7 @@ void MainWindow::restoreMainWindow() {
         SettingsManager::instance().settings().value("geometry").toByteArray());
     QPoint pos = QCursor::pos();
     auto localScreens = QGuiApplication::screens();
-    for (auto screen : qAsConst(localScreens)) {
+    for (auto screen : std::as_const(localScreens)) {
       QRect screenRect = screen->geometry();
       if (screenRect.contains(pos)) {
         this->move(screenRect.center() - this->rect().center());
@@ -578,7 +578,7 @@ void MainWindow::notificationClicked() {
 void MainWindow::createActions() {
 
   m_openUrlAction = new QAction("New Chat", this);
-  m_openUrlAction->setShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key_N));
+  m_openUrlAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_N));
   connect(m_openUrlAction, &QAction::triggered, this, &MainWindow::newChat);
   addAction(m_openUrlAction);
 
@@ -593,7 +593,7 @@ void MainWindow::createActions() {
   addAction(m_minimizeAction);
 
   QShortcut *minimizeShortcut = new QShortcut(
-      QKeySequence(Qt::Modifier::CTRL + Qt::Key_W), this, SLOT(hide()));
+      QKeySequence(Qt::Modifier::CTRL | Qt::Key_W), this, SLOT(hide()));
   minimizeShortcut->setAutoRepeat(false);
 
   m_restoreAction = new QAction(tr("&Restore"), this);
@@ -607,19 +607,19 @@ void MainWindow::createActions() {
   addAction(m_reloadAction);
 
   m_lockAction = new QAction(tr("Loc&k"), this);
-  m_lockAction->setShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key_L));
+  m_lockAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_L));
   connect(m_lockAction, &QAction::triggered, this, &MainWindow::lockApp);
   addAction(m_lockAction);
 
   m_settingsAction = new QAction(tr("&Settings"), this);
-  m_settingsAction->setShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key_P));
+  m_settingsAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_P));
   connect(m_settingsAction, &QAction::triggered, this,
           &MainWindow::showSettings);
   addAction(m_settingsAction);
 
   m_toggleThemeAction = new QAction(tr("&Toggle theme"), this);
   m_toggleThemeAction->setShortcut(
-      QKeySequence(Qt::Modifier::CTRL + Qt::Key_T));
+      QKeySequence(Qt::Modifier::CTRL | Qt::Key_T));
   connect(m_toggleThemeAction, &QAction::triggered, this,
           &MainWindow::toggleTheme);
   addAction(m_toggleThemeAction);
@@ -628,7 +628,7 @@ void MainWindow::createActions() {
   connect(m_aboutAction, &QAction::triggered, this, &MainWindow::showAbout);
 
   m_quitAction = new QAction(tr("&Quit"), this);
-  m_quitAction->setShortcut(QKeySequence(Qt::Modifier::CTRL + Qt::Key_Q));
+  m_quitAction->setShortcut(QKeySequence(Qt::Modifier::CTRL | Qt::Key_Q));
   connect(m_quitAction, &QAction::triggered, this, &MainWindow::quitApp);
   addAction(m_quitAction);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -244,7 +244,7 @@ void MainWindow::tryLogOut() {
 }
 
 void MainWindow::initSettingWidget() {
-  int screenNumber = qApp->desktop()->screenNumber(this);
+  int screenNumber = qApp->screens().indexOf(screen());
   if (m_settingsWidget == nullptr) {
     m_settingsWidget = new SettingsWidget(
         this, screenNumber, m_webEngine->page()->profile()->cachePath(),
@@ -451,8 +451,7 @@ void MainWindow::showSettings(bool isAskedByCLI) {
   if (!m_settingsWidget->isVisible()) {
     this->updateSettingsUserAgentWidget();
     m_settingsWidget->refresh();
-    int screenNumber = qApp->desktop()->screenNumber(this);
-    QRect screenRect = QGuiApplication::screens().at(screenNumber)->geometry();
+    QRect screenRect = screen()->geometry();
     if (!screenRect.contains(m_settingsWidget->pos())) {
       m_settingsWidget->move(screenRect.center() -
                              m_settingsWidget->rect().center());

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -15,7 +15,6 @@
 #include <QStyle>
 #include <QStyleFactory>
 #include <QSystemTrayIcon>
-#include <QWebEngineContextMenuData>
 #include <QWebEngineCookieStore>
 #include <QWebEngineFullScreenRequest>
 #include <QWebEngineProfile>

--- a/src/notificationpopup.h
+++ b/src/notificationpopup.h
@@ -6,13 +6,11 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
 #include <QPropertyAnimation>
 #include <QPushButton>
-#include <QScreen>
 #include <QScreen>
 #include <QSpacerItem>
 #include <QTimer>
@@ -131,13 +129,11 @@ protected slots:
   }
 
   void onClosed() {
-    auto x = this->pos().x();
-    auto y = this->pos().y();
+    auto pos = mapToGlobal(QPoint(0, 0));
     QPropertyAnimation *a = new QPropertyAnimation(this, "pos");
     a->setDuration(150);
-    a->setStartValue(QApplication::desktop()->mapToGlobal(QPoint(x, y)));
-    a->setEndValue(QApplication::desktop()->mapToGlobal(
-        QPoint(x, -(this->height() + 20))));
+    a->setStartValue(pos);
+    a->setEndValue(QPoint(pos.x(), -(this->height() + 20)));
     a->setEasingCurve(QEasingCurve::Linear);
 
     connect(a, &QPropertyAnimation::finished, this, [=]() {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -134,7 +134,7 @@ QString Utils::convertSectoDay(qint64 secs) {
 QString
 Utils::returnPath(QString pathname,
                   QString standardLocation = QStandardPaths::writableLocation(
-                      QStandardPaths::DataLocation)) {
+                      QStandardPaths::AppLocalDataLocation)) {
   QChar sepe = QDir::separator();
   QDir d(standardLocation + sepe + pathname);
   d.mkpath(standardLocation + sepe + pathname);

--- a/src/webenginepage.h
+++ b/src/webenginepage.h
@@ -36,9 +36,14 @@ protected:
                                QWebEnginePage::NavigationType type,
                                bool isMainFrame) override;
   QWebEnginePage *createWindow(QWebEnginePage::WebWindowType type) override;
-  bool certificateError(const QWebEngineCertificateError &error) override;
   QStringList chooseFiles(FileSelectionMode mode, const QStringList &oldFiles,
                           const QStringList &acceptedMimeTypes) override;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  void handleCertificateError(const QWebEngineCertificateError &error);
+#else
+  bool certificateError(const QWebEngineCertificateError &error) override;
+#endif
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
   inline QWidget *view() {

--- a/src/webenginepage.h
+++ b/src/webenginepage.h
@@ -16,6 +16,10 @@
 #include <QWebEngineRegisterProtocolHandlerRequest>
 #include <QWebEngineSettings>
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QWebEngineView>
+#endif
+
 #include "settingsmanager.h"
 
 #include "ui_certificateerrordialog.h"
@@ -35,6 +39,12 @@ protected:
   bool certificateError(const QWebEngineCertificateError &error) override;
   QStringList chooseFiles(FileSelectionMode mode, const QStringList &oldFiles,
                           const QStringList &acceptedMimeTypes) override;
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  inline QWidget *view() {
+      return QWebEngineView::forPage(this);
+  }
+#endif
 
 public slots:
   void handleFeaturePermissionRequested(const QUrl &securityOrigin,

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -120,7 +120,7 @@ void WebView::contextMenuEvent(QContextMenuEvent *event) {
 
   if (pageWebengineProfile->isSpellCheckEnabled()) {
     auto subMenu = menu->addMenu(tr("Select Language"));
-    for (const QString &dict : qAsConst(m_dictionaries)) {
+    for (const QString &dict : std::as_const(m_dictionaries)) {
       auto action = subMenu->addAction(dict);
       action->setCheckable(true);
       action->setChecked(languages.contains(dict));

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -2,9 +2,15 @@
 
 #include <QContextMenuEvent>
 #include <QMenu>
-#include <QWebEngineContextMenuData>
 #include <QWebEngineProfile>
 #include <mainwindow.h>
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QWebEngineContextMenuRequest>
+using QWebEngineContextMenuData = QWebEngineContextMenuRequest;
+#else
+#include <QWebEngineContextMenuData>
+#endif
 
 WebView::WebView(QWidget *parent, QStringList dictionaries)
     : QWebEngineView(parent), m_dictionaries(dictionaries) {
@@ -63,8 +69,11 @@ void WebView::wheelEvent(QWheelEvent *event) {
 }
 
 void WebView::contextMenuEvent(QContextMenuEvent *event) {
-
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  auto menu = createStandardContextMenu();
+#else
   auto menu = page()->createStandardContextMenu();
+#endif
   menu->setAttribute(Qt::WA_DeleteOnClose, true);
   // hide reload, back, forward, savepage, copyimagelink menus
   foreach (auto *action, menu->actions()) {
@@ -77,8 +86,12 @@ void WebView::contextMenuEvent(QContextMenuEvent *event) {
     }
   }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+  const QWebEngineContextMenuRequest &data = *lastContextMenuRequest();
+#else
   const QWebEngineContextMenuData &data = page()->contextMenuData();
   Q_ASSERT(data.isValid());
+#endif
 
   // allow context menu on image
   if (data.mediaType() == QWebEngineContextMenuData::MediaTypeImage) {

--- a/src/widgets/MoreApps/moreapps.cpp
+++ b/src/widgets/MoreApps/moreapps.cpp
@@ -104,7 +104,7 @@ QList<AppItem> MoreApps::prepareAppsToShow(const QByteArray &bytes) {
   }
 
   QJsonArray jsonArray = jsonResponse.object().value("results").toArray();
-  foreach (const QJsonValue &val, jsonArray) {
+  for (const QJsonValue &val : jsonArray) {
     QJsonObject object = val.toObject();
 
     // publisher
@@ -127,7 +127,7 @@ QList<AppItem> MoreApps::prepareAppsToShow(const QByteArray &bytes) {
     QJsonArray mediaArr =
         object.value("snap").toObject().value("media").toArray();
     QString iconUrl;
-    foreach (const QJsonValue &mediaItem, mediaArr) {
+    for (const QJsonValue &mediaItem : mediaArr) {
       if (mediaItem.toObject().value("type") == "icon")
         iconUrl = mediaItem.toObject().value("url").toString();
     }
@@ -252,7 +252,7 @@ void MoreApps::showApps() {
   if (mRemoteIconPreCaching) {
     // cache fallback icon
     setRemoteIcon(fallbackIconUrl, nullptr);
-    foreach (auto a, mAppList) {
+    for (auto &a : mAppList) {
       auto iconUrl = a.getIconUrl();
       // qDebug() << "pre-caching icon for" << a.getName();
       setRemoteIcon(iconUrl, nullptr);


### PR DESCRIPTION
Here is a quick attempt to allow building against Qt 6. Qt 5.15 is still supported using conditional compilation. Very light testing was done on 6.8 and 5.15.

This only makes the minimum amount of changes necessary. Renamed classes are #included and aliased to their old name where possible and deprecated things are left alone if they are still included in 6.8 and the replacement was introduced after 5.15.

I've split up the changes into commits by what Qt6 change they address. I can squash them down if wanted.