### PR TITLE
fix: port codebase to Qt 6 API

### DIFF
--- a/src/WhatsApp.pro
+++ b/src/WhatsApp.pro
@@ -23,7 +23,7 @@ equals(QMAKE_HOST.arch, aarch64) {
 # Uncomment if you need specific linker flags as well
 #QMAKE_LFLAGS += $$QMAKE_LDFLAGS
 
-QT += core gui webengine webenginewidgets positioning
+QT += core gui webenginewidgets positioning
 
 CONFIG += c++17
 
@@ -33,13 +33,8 @@ CONFIG += c++17
 
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-!qtConfig(webengine-spellchecker) {
-    error("Qt WebEngine compiled without spellchecker support, this example will not work.")
-}
-
-qtConfig(webengine-native-spellchecker) {
-    error("Spellcheck example can not be built when using native OS dictionaries.")
-}
+# Spellchecker feature checks removed — Qt 6.8+ includes spellchecker by default
+# and no longer exposes the webengine-spellchecker feature flag.
 
 TARGET = whatsie
 TEMPLATE = app

--- a/src/automatictheme.cpp
+++ b/src/automatictheme.cpp
@@ -47,7 +47,7 @@ AutomaticTheme::AutomaticTheme(QWidget *parent)
                 ui->refresh->setEnabled(false);
               }
             });
-    connect(m_gPosInfoSrc, &QGeoPositionInfoSource::updateTimeout, this, [=]() {
+    connect(m_gPosInfoSrc, &QGeoPositionInfoSource::errorOccurred, this, [=]() {
       if (!SettingsManager::instance().settings().value("sunrise").isValid() ||
           !SettingsManager::instance().settings().value("sunset").isValid()) {
         if (ui->refresh->isEnabled())
@@ -77,9 +77,9 @@ void AutomaticTheme::on_refresh_clicked() {
   if (geoCor.isValid()) {
     Sunclock sun(this->m_latitube, this->m_longitude, this->m_hourOffset);
     m_sunrise.setSecsSinceEpoch(
-        sun.sunrise(QDateTime::currentDateTimeUtc().toTime_t()));
+        sun.sunrise(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()));
     m_sunset.setSecsSinceEpoch(
-        sun.sunset(QDateTime::currentDateTimeUtc().toTime_t()));
+        sun.sunset(QDateTime::currentDateTimeUtc().toSecsSinceEpoch()));
 
     ui->sunrise->setTime(m_sunrise.time());
     ui->sunset->setTime(m_sunset.time());

--- a/src/downloadmanagerwidget.cpp
+++ b/src/downloadmanagerwidget.cpp
@@ -6,16 +6,16 @@ DownloadManagerWidget::DownloadManagerWidget(QWidget *parent)
   setupUi(this);
 }
 
-void DownloadManagerWidget::acceptDownload(QWebEngineDownloadItem *download) {
+void DownloadManagerWidget::acceptDownload(QWebEngineDownloadRequest *download) {
   download->accept();
   add(new DownloadWidget(download));
   show();
 }
 
 void DownloadManagerWidget::downloadRequested(
-    QWebEngineDownloadItem *download) {
+    QWebEngineDownloadRequest *download) {
   Q_ASSERT(download &&
-           download->state() == QWebEngineDownloadItem::DownloadRequested);
+           download->state() == QWebEngineDownloadRequest::DownloadRequested);
   QString path =
       SettingsManager::instance().settings().value("defaultDownloadLocation",
                  QStandardPaths::writableLocation(

--- a/src/downloadmanagerwidget.h
+++ b/src/downloadmanagerwidget.h
@@ -57,11 +57,11 @@
 
 #include <QFileDialog>
 #include <QStandardPaths>
-#include <QWebEngineDownloadItem>
+#include <QWebEngineDownloadRequest>
 #include <QWidget>
 
 QT_BEGIN_NAMESPACE
-class QWebEngineDownloadItem;
+class QWebEngineDownloadRequest;
 QT_END_NAMESPACE
 
 class DownloadWidget;
@@ -74,16 +74,16 @@ public:
   explicit DownloadManagerWidget(QWidget *parent = nullptr);
 
   // Prompts user with a "Save As" dialog. If the user doesn't cancel it, then
-  // the QWebEngineDownloadItem will be accepted and the DownloadManagerWidget
+  // the QWebEngineDownloadRequest will be accepted and the DownloadManagerWidget
   // will be shown on the screen.
-  void downloadRequested(QWebEngineDownloadItem *webItem);
+  void downloadRequested(QWebEngineDownloadRequest *webItem);
 
 protected slots:
   void keyPressEvent(QKeyEvent *e);
 private slots:
   void on_open_download_dir_clicked();
 
-  void acceptDownload(QWebEngineDownloadItem *download);
+  void acceptDownload(QWebEngineDownloadRequest *download);
 
   void on_clear_all_downlads_clicked();
 

--- a/src/downloadwidget.cpp
+++ b/src/downloadwidget.cpp
@@ -4,9 +4,9 @@
 #include <QDesktopServices>
 #include <QFileInfo>
 #include <QUrl>
-#include <QWebEngineDownloadItem>
+#include <QWebEngineDownloadRequest>
 
-DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download,
+DownloadWidget::DownloadWidget(QWebEngineDownloadRequest *download,
                                QWidget *parent)
     : QFrame(parent), m_download(download) {
   setupUi(this);
@@ -26,22 +26,24 @@ DownloadWidget::DownloadWidget(QWebEngineDownloadItem *download,
   }
 
   connect(openButton, &QPushButton::clicked, m_download, [this](bool) {
-    if (m_download->state() == QWebEngineDownloadItem::DownloadCompleted) {
+    if (m_download->state() == QWebEngineDownloadRequest::DownloadCompleted) {
           Utils::desktopOpenUrl(m_download->downloadFileName());
     }
   });
 
   connect(cancelButton, &QPushButton::clicked, m_download, [this](bool) {
-    if (m_download->state() == QWebEngineDownloadItem::DownloadInProgress)
+    if (m_download->state() == QWebEngineDownloadRequest::DownloadInProgress)
       m_download->cancel();
     else
       emit removeClicked(this);
   });
 
-  connect(m_download, &QWebEngineDownloadItem::downloadProgress, this,
+  connect(m_download, &QWebEngineDownloadRequest::receivedBytesChanged, this,
+          &DownloadWidget::updateWidget);
+  connect(m_download, &QWebEngineDownloadRequest::totalBytesChanged, this,
           &DownloadWidget::updateWidget);
 
-  connect(m_download, &QWebEngineDownloadItem::stateChanged, this,
+  connect(m_download, &QWebEngineDownloadRequest::stateChanged, this,
           &DownloadWidget::updateWidget);
 
   updateWidget();
@@ -65,7 +67,7 @@ inline QString DownloadWidget::withUnit(qreal bytes) {
 
 bool DownloadWidget::isDownloading() {
 
-  return m_download->state() == QWebEngineDownloadItem::DownloadInProgress;
+  return m_download->state() == QWebEngineDownloadRequest::DownloadInProgress;
 }
 
 void DownloadWidget::updateWidget() {
@@ -75,10 +77,10 @@ void DownloadWidget::updateWidget() {
 
   auto state = m_download->state();
   switch (state) {
-  case QWebEngineDownloadItem::DownloadRequested:
+  case QWebEngineDownloadRequest::DownloadRequested:
     Q_UNREACHABLE();
     break;
-  case QWebEngineDownloadItem::DownloadInProgress:
+  case QWebEngineDownloadRequest::DownloadInProgress:
     if (totalBytes >= 0) {
       progressBar->setValue(qRound(100 * receivedBytes / totalBytes));
       progressBar->setDisabled(false);
@@ -95,7 +97,7 @@ void DownloadWidget::updateWidget() {
     }
     openButton->setEnabled(false);
     break;
-  case QWebEngineDownloadItem::DownloadCompleted:
+  case QWebEngineDownloadRequest::DownloadCompleted:
     progressBar->setValue(100);
     progressBar->setDisabled(true);
     progressBar->setFormat(
@@ -103,7 +105,7 @@ void DownloadWidget::updateWidget() {
             .arg(withUnit(receivedBytes), withUnit(bytesPerSecond)));
     openButton->setEnabled(true);
     break;
-  case QWebEngineDownloadItem::DownloadCancelled:
+  case QWebEngineDownloadRequest::DownloadCancelled:
     progressBar->setValue(0);
     progressBar->setDisabled(true);
     progressBar->setFormat(
@@ -111,7 +113,7 @@ void DownloadWidget::updateWidget() {
             .arg(withUnit(receivedBytes), withUnit(bytesPerSecond)));
     openButton->setEnabled(false);
     break;
-  case QWebEngineDownloadItem::DownloadInterrupted:
+  case QWebEngineDownloadRequest::DownloadInterrupted:
     progressBar->setValue(0);
     progressBar->setDisabled(true);
     progressBar->setFormat(
@@ -120,7 +122,7 @@ void DownloadWidget::updateWidget() {
     break;
   }
 
-  if (state == QWebEngineDownloadItem::DownloadInProgress) {
+  if (state == QWebEngineDownloadRequest::DownloadInProgress) {
     static QIcon cancelIcon(":/icons/stop-line.png");
     cancelButton->setIcon(cancelIcon);
     cancelButton->setToolTip(tr("Stop downloading"));

--- a/src/downloadwidget.h
+++ b/src/downloadwidget.h
@@ -59,15 +59,15 @@
 #include <QTime>
 
 QT_BEGIN_NAMESPACE
-class QWebEngineDownloadItem;
+class QWebEngineDownloadRequest;
 QT_END_NAMESPACE
 
-// Displays one ongoing or finished download (QWebEngineDownloadItem).
+// Displays one ongoing or finished download (QWebEngineDownloadRequest).
 class DownloadWidget final : public QFrame, public Ui::DownloadWidget {
   Q_OBJECT
 public:
-  // Precondition: The QWebEngineDownloadItem has been accepted.
-  explicit DownloadWidget(QWebEngineDownloadItem *download,
+  // Precondition: The QWebEngineDownloadRequest has been accepted.
+  explicit DownloadWidget(QWebEngineDownloadRequest *download,
                           QWidget *parent = nullptr);
 
 public slots:
@@ -86,7 +86,7 @@ private slots:
 private:
   QString withUnit(qreal bytes);
 
-  QWebEngineDownloadItem *m_download;
+  QWebEngineDownloadRequest *m_download;
   QElapsedTimer m_timeAdded;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 #include <QDebug>
 #include <QWebEngineProfile>
 #include <QWebEngineSettings>
-#include <QtWebEngine>
 #include <QtWidgets>
 
 #include "common.h"
@@ -13,16 +12,14 @@
 
 int main(int argc, char *argv[]) {
 
-  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-
 #ifdef QT_DEBUG
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS",
           "--remote-debugging-port=9421 --ignore-gpu-blocklist --no-sandbox "
-          "--single-process --disable-extensions");
+          "--disable-extensions");
 #else
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS",
           "--disable-logging --ignore-gpu-blocklist --no-sandbox "
-          "--single-process --disable-extensions");
+          "--disable-extensions");
 #endif
 
   SingleApplication instance(argc, argv, true);
@@ -136,11 +133,11 @@ int main(int argc, char *argv[]) {
     return 0;
   }
 
-  QWebEngineSettings::defaultSettings()->setAttribute(
+  QWebEngineProfile::defaultProfile()->settings()->setAttribute(
       QWebEngineSettings::DnsPrefetchEnabled, true);
-  QWebEngineSettings::defaultSettings()->setAttribute(
+  QWebEngineProfile::defaultProfile()->settings()->setAttribute(
       QWebEngineSettings::FullScreenSupportEnabled, true);
-  QWebEngineSettings::defaultSettings()->setAttribute(
+  QWebEngineProfile::defaultProfile()->settings()->setAttribute(
       QWebEngineSettings::JavascriptCanAccessClipboard, true);
 
   MainWindow whatsie;
@@ -153,7 +150,7 @@ int main(int argc, char *argv[]) {
         qInfo().noquote() << "Another instance with PID: " +
                                  QString::number(instanceId) +
                                  ", sent argument: " + message;
-        QString messageStr = QTextCodec::codecForMib(106)->toUnicode(message);
+        QString messageStr = QString::fromUtf8(message);
 
         QCommandLineParser p;
         p.addOptions(secondaryInstanceCLIOptions);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -244,7 +244,7 @@ void MainWindow::tryLogOut() {
 }
 
 void MainWindow::initSettingWidget() {
-  int screenNumber = qApp->desktop()->screenNumber(this);
+  int screenNumber = QGuiApplication::screens().indexOf(this->screen());
   if (m_settingsWidget == nullptr) {
     m_settingsWidget = new SettingsWidget(
         this, screenNumber, m_webEngine->page()->profile()->cachePath(),
@@ -451,8 +451,7 @@ void MainWindow::showSettings(bool isAskedByCLI) {
   if (!m_settingsWidget->isVisible()) {
     this->updateSettingsUserAgentWidget();
     m_settingsWidget->refresh();
-    int screenNumber = qApp->desktop()->screenNumber(this);
-    QRect screenRect = QGuiApplication::screens().at(screenNumber)->geometry();
+    QRect screenRect = this->screen()->geometry();
     if (!screenRect.contains(m_settingsWidget->pos())) {
       m_settingsWidget->move(screenRect.center() -
                              m_settingsWidget->rect().center());
@@ -1131,7 +1130,7 @@ void MainWindow::loadingQuirk(const QString &test) {
 
 // unused direct method to download file without having entry in download
 // manager
-void MainWindow::handleDownloadRequested(QWebEngineDownloadItem *download) {
+void MainWindow::handleDownloadRequested(QWebEngineDownloadRequest *download) {
   QFileDialog dialog(this);
   bool usenativeFileDialog = SettingsManager::instance()
                                  .settings()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -15,7 +15,7 @@
 #include <QStyle>
 #include <QStyleFactory>
 #include <QSystemTrayIcon>
-#include <QWebEngineContextMenuData>
+#include <QWebEngineContextMenuRequest>
 #include <QWebEngineCookieStore>
 #include <QWebEngineFullScreenRequest>
 #include <QWebEngineProfile>
@@ -53,7 +53,7 @@ public slots:
   void updatePageTheme();
   void handleWebViewTitleChanged(const QString &title);
   void handleLoadFinished(bool loaded);
-  void handleDownloadRequested(QWebEngineDownloadItem *download);
+  void handleDownloadRequested(QWebEngineDownloadRequest *download);
   void showSettings(bool isAskedByCLI = false);
   void showAbout();
   void lockApp();

--- a/src/notificationpopup.h
+++ b/src/notificationpopup.h
@@ -6,7 +6,6 @@
 
 #include <QApplication>
 #include <QDebug>
-#include <QDesktopWidget>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMouseEvent>
@@ -135,9 +134,8 @@ protected slots:
     auto y = this->pos().y();
     QPropertyAnimation *a = new QPropertyAnimation(this, "pos");
     a->setDuration(150);
-    a->setStartValue(QApplication::desktop()->mapToGlobal(QPoint(x, y)));
-    a->setEndValue(QApplication::desktop()->mapToGlobal(
-        QPoint(x, -(this->height() + 20))));
+    a->setStartValue(this->mapToGlobal(QPoint(0, 0)));
+    a->setEndValue(QPoint(x, -(this->height() + 20)));
     a->setEasingCurve(QEasingCurve::Linear);
 
     connect(a, &QPropertyAnimation::finished, this, [=]() {

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -568,9 +568,10 @@ void SettingsWidget::showSetApplockPasswordDialog() {
   }
 }
 
-void SettingsWidget::on_dictComboBox_currentIndexChanged(const QString &arg1) {
-  SettingsManager::instance().settings().setValue("sc_dict", arg1);
-  emit dictChanged(arg1);
+void SettingsWidget::on_dictComboBox_currentIndexChanged(int index) {
+  QString text = ui->dictComboBox->itemText(index);
+  SettingsManager::instance().settings().setValue("sc_dict", text);
+  emit dictChanged(text);
 }
 
 void SettingsWidget::on_enableSpellCheck_toggled(bool checked) {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -67,7 +67,7 @@ private slots:
   void on_chnageCurrentPasswordPushButton_clicked();
   void on_closeButtonActionComboBox_currentIndexChanged(int index);
   void on_defaultUserAgentButton_clicked();
-  void on_dictComboBox_currentIndexChanged(const QString &arg1);
+  void on_dictComboBox_currentIndexChanged(int index);
   void on_enableSpellCheck_toggled(bool checked);
   void on_minimizeOnTrayIconClick_toggled(bool checked);
   void on_muteAudioCheckBox_toggled(bool checked);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -118,13 +118,13 @@ QString Utils::convertSectoDay(qint64 secs) {
  * The method constructs the full path by concatenating the specified `pathname`
  * with the provided `standardLocation`. If `standardLocation` is not provided,
  * the default value is obtained from
- * `QStandardPaths::writableLocation(QStandardPaths::DataLocation)`.
+ * `QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)`.
  *
  * @param pathname The name of the file or directory within the specified
  * location.
  * @param standardLocation (optional) The base directory to prepend to
  * `pathname`. Default value:
- * QStandardPaths::writableLocation(QStandardPaths::DataLocation).
+ * QStandardPaths::writableLocation(QStandardPaths::AppDataLocation).
  *
  * @return The full path, including the `pathname` and the `standardLocation`,
  * separated by the appropriate directory separator. If the specified location
@@ -134,7 +134,7 @@ QString Utils::convertSectoDay(qint64 secs) {
 QString
 Utils::returnPath(QString pathname,
                   QString standardLocation = QStandardPaths::writableLocation(
-                      QStandardPaths::DataLocation)) {
+                      QStandardPaths::AppDataLocation)) {
   QChar sepe = QDir::separator();
   QDir d(standardLocation + sepe + pathname);
   d.mkpath(standardLocation + sepe + pathname);

--- a/src/webenginepage.cpp
+++ b/src/webenginepage.cpp
@@ -21,6 +21,8 @@ WebEnginePage::WebEnginePage(QWebEngineProfile *profile, QObject *parent)
           &WebEnginePage::handleProxyAuthenticationRequired);
   connect(this, &QWebEnginePage::registerProtocolHandlerRequested, this,
           &WebEnginePage::handleRegisterProtocolHandlerRequested);
+  connect(this, &QWebEnginePage::certificateError, this,
+          &WebEnginePage::handleCertificateError);
 
 #if !defined(QT_NO_SSL) || QT_VERSION >= QT_VERSION_CHECK(5, 12, 0)
   connect(this, &QWebEnginePage::selectClientCertificate, this,
@@ -101,7 +103,7 @@ void WebEnginePage::handleFeaturePermissionRequested(const QUrl &securityOrigin,
         QWebEnginePage::PermissionPolicy::PermissionGrantedByUser);
   } else {
     if (!question.isEmpty() &&
-        QMessageBox::question(view()->window(), title, question) ==
+        QMessageBox::question(QApplication::activeWindow(), title, question) ==
             QMessageBox::Yes) {
       setFeaturePermission(
           securityOrigin, feature,
@@ -196,9 +198,10 @@ QStringList WebEnginePage::chooseFiles(QWebEnginePage::FileSelectionMode mode,
   return selectedFiles;
 }
 
-bool WebEnginePage::certificateError(const QWebEngineCertificateError &error) {
-  QWidget *mainWindow = view()->window();
+void WebEnginePage::handleCertificateError(QWebEngineCertificateError error) {
+  QWidget *mainWindow = QApplication::activeWindow();
   if (error.isOverridable()) {
+    error.defer();
     QDialog dialog(mainWindow);
     dialog.setModal(true);
     dialog.setWindowFlags(dialog.windowFlags() &
@@ -209,19 +212,23 @@ bool WebEnginePage::certificateError(const QWebEngineCertificateError &error) {
     QIcon icon(mainWindow->style()->standardIcon(QStyle::SP_MessageBoxWarning,
                                                  nullptr, mainWindow));
     certificateDialog.m_iconLabel->setPixmap(icon.pixmap(32, 32));
-    certificateDialog.m_errorLabel->setText(error.errorDescription());
+    certificateDialog.m_errorLabel->setText(error.description());
     dialog.setWindowTitle(tr("Certificate Error"));
-    return dialog.exec() == QDialog::Accepted;
+    if (dialog.exec() == QDialog::Accepted)
+      error.acceptCertificate();
+    else
+      error.rejectCertificate();
+    return;
   }
 
   QMessageBox::critical(mainWindow, tr("Certificate Error"),
-                        error.errorDescription());
-  return false;
+                        error.description());
+  error.rejectCertificate();
 }
 
 void WebEnginePage::handleAuthenticationRequired(const QUrl &requestUrl,
                                                  QAuthenticator *auth) {
-  QWidget *mainWindow = view()->window();
+  QWidget *mainWindow = QApplication::activeWindow();
   QDialog dialog(mainWindow);
   dialog.setModal(true);
   dialog.setWindowFlags(dialog.windowFlags() &
@@ -252,7 +259,7 @@ void WebEnginePage::handleAuthenticationRequired(const QUrl &requestUrl,
 
 void WebEnginePage::handleProxyAuthenticationRequired(
     const QUrl &, QAuthenticator *auth, const QString &proxyHost) {
-  QWidget *mainWindow = view()->window();
+  QWidget *mainWindow = QApplication::activeWindow();
   QDialog dialog(mainWindow);
   dialog.setModal(true);
   dialog.setWindowFlags(dialog.windowFlags() &
@@ -284,7 +291,7 @@ void WebEnginePage::handleProxyAuthenticationRequired(
 void WebEnginePage::handleRegisterProtocolHandlerRequested(
     QWebEngineRegisterProtocolHandlerRequest request) {
   auto answer = QMessageBox::question(
-      view()->window(), tr("Permission Request"),
+      QApplication::activeWindow(), tr("Permission Request"),
       tr("Allow %1 to open all %2 links?")
           .arg(request.origin().host(), request.scheme()));
   if (answer == QMessageBox::Yes)

--- a/src/webenginepage.h
+++ b/src/webenginepage.h
@@ -32,7 +32,7 @@ protected:
                                QWebEnginePage::NavigationType type,
                                bool isMainFrame) override;
   QWebEnginePage *createWindow(QWebEnginePage::WebWindowType type) override;
-  bool certificateError(const QWebEngineCertificateError &error) override;
+  void handleCertificateError(QWebEngineCertificateError error);
   QStringList chooseFiles(FileSelectionMode mode, const QStringList &oldFiles,
                           const QStringList &acceptedMimeTypes) override;
 

--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -2,7 +2,7 @@
 
 #include <QContextMenuEvent>
 #include <QMenu>
-#include <QWebEngineContextMenuData>
+#include <QWebEngineContextMenuRequest>
 #include <QWebEngineProfile>
 #include <mainwindow.h>
 
@@ -64,7 +64,7 @@ void WebView::wheelEvent(QWheelEvent *event) {
 
 void WebView::contextMenuEvent(QContextMenuEvent *event) {
 
-  auto menu = page()->createStandardContextMenu();
+  auto menu = createStandardContextMenu();
   menu->setAttribute(Qt::WA_DeleteOnClose, true);
   // hide reload, back, forward, savepage, copyimagelink menus
   foreach (auto *action, menu->actions()) {
@@ -77,16 +77,16 @@ void WebView::contextMenuEvent(QContextMenuEvent *event) {
     }
   }
 
-  const QWebEngineContextMenuData &data = page()->contextMenuData();
-  Q_ASSERT(data.isValid());
+  const QWebEngineContextMenuRequest *data = lastContextMenuRequest();
+  Q_ASSERT(data);
 
   // allow context menu on image
-  if (data.mediaType() == QWebEngineContextMenuData::MediaTypeImage) {
+  if (data->mediaType() == QWebEngineContextMenuRequest::MediaTypeImage) {
     QWebEngineView::contextMenuEvent(event);
     return;
   }
   // if content is not editable
-  if (data.selectedText().isEmpty() && !data.isContentEditable()) {
+  if (data->selectedText().isEmpty() && !data->isContentEditable()) {
     event->ignore();
     return;
   }


### PR DESCRIPTION
## Summary
- Migrate all deprecated/removed Qt 5 APIs to Qt 6 equivalents, enabling the project to build and run on Qt 6.8+
- Replace removed classes (`QWebEngineDownloadItem`, `QWebEngineContextMenuData`, `QDesktopWidget`, `QTextCodec`), signals (`downloadProgress`, `updateTimeout`), and methods (`view()`, `defaultSettings()`, `toTime_t()`)
- Remove obsolete spellchecker feature checks, `--single-process` chromium flag, and `AA_EnableHighDpiScaling`

## Test plan
- [x] Builds successfully with Qt 6.10.1 on Fedora 43 (aarch64)
- [x] Application launches without fatal errors
- [ ] Verify download manager works (file downloads, progress, cancel)
- [ ] Verify certificate error dialog appears for invalid certs
- [ ] Verify context menu works (spellcheck, image save)
- [ ] Verify automatic theme switching with geo-positioning
- [ ] Verify settings dialog dictionary combo box works
- [ ] Verify notification popups animate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)