### PR TITLE
Remove notification when minimizing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -352,14 +352,6 @@ void MainWindow::closeEvent(QCloseEvent *event) {
               .toInt() == 0) {
     hide();
     event->ignore();
-    if (SettingsManager::instance()
-            .settings()
-            .value("firstrun_tray", true)
-            .toBool()) {
-      showNotification(QApplication::applicationName(),
-                       "Minimized to system tray.");
-      SettingsManager::instance().settings().setValue("firstrun_tray", false);
-    }
     return;
   }
   event->accept();
@@ -371,7 +363,7 @@ void MainWindow::quitApp() {
   SettingsManager::instance().settings().setValue("geometry", saveGeometry());
   getPageTheme();
   QTimer::singleShot(500, this, [=]() {
-    SettingsManager::instance().settings().setValue("firstrun_tray", true);
+    // Not sure if still need the timer now
     qApp->quit();
   });
 }


### PR DESCRIPTION
Looks messy and adds clutter to desktop notification history. I think most other apps that have an option to minimize to the system tray don't notify the user when they do so, even though I appreciate that the notification will only be shown once per session.

Note this is different to #266 as this one is not about the startup notification.

Partial fix for #205.