### PR TITLE
Remove notification when restored existing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -248,7 +248,7 @@ int main(int argc, char *argv[]) {
                   << "x-schema-handler";
           whatsie.loadSchemaUrl(urlStr);
         } else {
-          whatsie.alreadyRunning(true);
+          whatsie.alreadyRunning();
         }
       });
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -382,10 +382,7 @@ void MainWindow::runMinimized() {
                    "Whatsie started minimized in system tray. Click to Open.");
 }
 
-void MainWindow::alreadyRunning(bool notify) {
-  if (notify)
-    showNotification(QApplication::applicationName(),
-                     "Restored an already running instance.");
+void MainWindow::alreadyRunning() {
   setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
   show();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -20,7 +20,7 @@ public:
   ~MainWindow();
 
   void loadSchemaUrl(const QString &arg);
-  void alreadyRunning(bool notify = false);
+  void alreadyRunning();
   void runMinimized();
   void showNotification(QString title, QString message);
   void doReload(bool byPassCache = false, bool isAskedByCLI = false,


### PR DESCRIPTION
Looks messy, adds clutter to desktop notification history, and is simply unnecessary. The user can see that the existing instance is restored with their own eyes.