### PR TITLE
Add setting: close emoji/sticker panel on outside click

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SOURCES
     src/webenginepage.cpp
     src/webenginenotifproxy.cpp
     src/webengineprofilemanager.cpp
+    src/webtweaks.cpp
     src/webview.cpp
     src/widgets/elidedlabel/elidedlabel.cpp
     src/widgets/scrolltext/scrolltext.cpp
@@ -137,6 +138,7 @@ set(HEADERS
     src/utils.h
     src/webenginepage.h
     src/webengineprofilemanager.h
+    src/webtweaks.h
     src/webview.h
     src/webenginenotifproxy.h
     src/widgets/elidedlabel/elidedlabel.h

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -14,6 +14,7 @@
 #include "rateapp.h"
 #include "theme.h"
 #include "webengineprofilemanager.h"
+#include "webtweaks.h"
 
 extern double defaultZoomFactorMaximized;
 extern int    defaultAppAutoLockDuration;
@@ -224,6 +225,16 @@ void MainWindow::initSettingWidget() {
   connect(m_settingsWidget, &SettingsWidget::notificationPopupTimeOutChanged,
           m_settingsWidget, [=]() {
             setNotificationPresenter(m_webEngine->page()->profile());
+          });
+
+  connect(m_settingsWidget, &SettingsWidget::webTweaksChanged, m_settingsWidget,
+          [=]() {
+            // Update the profile scripts for future page loads, and apply the
+            // change to the already-loaded page (Qt does not propagate profile
+            // script changes to an existing page).
+            WebTweaks::install(WebEngineProfileManager::instance().profile());
+            if (m_webEngine && m_webEngine->page())
+              m_webEngine->page()->runJavaScript(WebTweaks::scriptSource());
           });
 
   connect(m_settingsWidget, &SettingsWidget::notify, m_settingsWidget,

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -85,6 +85,11 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                                      .settings()
                                      .value("startMinimized", false)
                                      .toBool());
+  ui->dismissEmojiPanelCheckBox->setChecked(
+      SettingsManager::instance()
+          .settings()
+          .value("webtweaks/dismissExpressionsPanel", false)
+          .toBool());
 
   this->appAutoLockingSetChecked(
       SettingsManager::instance()
@@ -584,6 +589,12 @@ void SettingsWidget::on_useNativeFileDialog_toggled(bool checked) {
 
 void SettingsWidget::on_startMinimized_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("startMinimized", checked);
+}
+
+void SettingsWidget::on_dismissEmojiPanelCheckBox_toggled(bool checked) {
+  SettingsManager::instance().settings().setValue(
+      "webtweaks/dismissExpressionsPanel", checked);
+  emit webTweaksChanged();
 }
 
 void SettingsWidget::on_appAutoLockcheckBox_toggled(bool checked) {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -23,6 +23,7 @@ signals:
   void initLock();
   void changeLockPassword();
   void notificationPopupTimeOutChanged();
+  void webTweaksChanged();
   void notify(QString message);
   void zoomChanged();
   void zoomMaximizedChanged();
@@ -65,6 +66,7 @@ private slots:
   void on_defaultUserAgentButton_clicked();
   void on_minimizeOnTrayIconClick_toggled(bool checked);
   void on_muteAudioCheckBox_toggled(bool checked);
+  void on_dismissEmojiPanelCheckBox_toggled(bool checked);
   void on_notificationCheckBox_toggled(bool checked);
   void on_notificationCombo_currentIndexChanged(int index);
   void on_notificationTimeOutspinBox_valueChanged(int arg1);

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -358,6 +358,16 @@ background:transparent;
               </property>
              </widget>
             </item>
+            <item row="4" column="1">
+             <widget class="QCheckBox" name="dismissEmojiPanelCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Close the emoji, GIF &amp;amp; sticker panel when you click elsewhere. WhatsApp Web otherwise keeps it open until the button is pressed again.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Close emoji/sticker panel when clicking outside</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item row="15" column="0">

--- a/src/webengineprofilemanager.cpp
+++ b/src/webengineprofilemanager.cpp
@@ -1,6 +1,7 @@
 #include "webengineprofilemanager.h"
 #include "common.h"
 #include "settingsmanager.h"
+#include "webtweaks.h"
 
 #include <QDebug>
 #include <QStandardPaths>
@@ -88,4 +89,6 @@ void WebEngineProfileManager::applyUserSettings() {
     m_profile->settings()->setAttribute(
         QWebEngineSettings::PlaybackRequiresUserGesture,
         s.value(QStringLiteral("autoPlayMedia"), false).toBool());
+
+    WebTweaks::install(m_profile);
 }

--- a/src/webtweaks.cpp
+++ b/src/webtweaks.cpp
@@ -1,0 +1,86 @@
+#include "webtweaks.h"
+#include "settingsmanager.h"
+
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
+
+static const char kScriptName[] = "whatsie-web-tweaks";
+
+// __FLAGS__ becomes a JSON object of the enabled tweaks. Behavior is gated by
+// the LIVE flags object (window.__whatsieWebTweaks) rather than a captured
+// boolean, so re-running this script on a loaded page toggles the tweak
+// without a reload. Every DOM access is wrapped so a stale selector can never
+// break the page.
+static const char kScriptTemplate[] = R"JS(
+(function () {
+  'use strict';
+  var FLAGS = __FLAGS__;
+  var W = window.__whatsieWebTweaks;
+  if (W) {
+    W.dismissExpressionsPanel = FLAGS.dismissExpressionsPanel;  // live update
+  } else {
+    W = window.__whatsieWebTweaks = FLAGS;
+  }
+  if (window.__whatsieWebTweaksReady) return;  // install listeners only once
+  window.__whatsieWebTweaksReady = true;
+
+  // ── Dismiss the expressions (emoji/GIF/sticker) panel on outside click. ──
+  // WhatsApp keeps it open until its button is pressed again. The panel mount
+  // node '#expressions-panel-container' always exists (empty, height 0); it is
+  // OPEN exactly when its child has a subtree. Close via a synthetic Escape.
+  var isOpen = function (c) {
+    return !!(c && c.firstElementChild && c.firstElementChild.childElementCount > 0);
+  };
+  document.addEventListener('pointerdown', function (ev) {
+    try {
+      if (!W.dismissExpressionsPanel) return;
+      var panel = document.querySelector('#expressions-panel-container');
+      if (!isOpen(panel) || panel.contains(ev.target)) return;
+      var btn = ev.target.closest && ev.target.closest('button');
+      if (btn && /emoji|gif|sticker/i.test(btn.getAttribute('aria-label') || ''))
+        return;
+      document.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'Escape', code: 'Escape', keyCode: 27, which: 27, bubbles: true,
+      }));
+    } catch (e) { /* never break the page */ }
+  }, true);
+})();
+)JS";
+
+namespace WebTweaks {
+
+QString scriptSource() {
+  QSettings &s = SettingsManager::instance().settings();
+  const bool dismiss =
+      s.value(QStringLiteral("webtweaks/dismissExpressionsPanel"), false).toBool();
+
+  const QString flags = QStringLiteral("{\"dismissExpressionsPanel\":%1}")
+      .arg(dismiss ? QStringLiteral("true") : QStringLiteral("false"));
+
+  QString source = QString::fromLatin1(kScriptTemplate);
+  source.replace(QLatin1String("__FLAGS__"), flags);
+  return source;
+}
+
+void install(QWebEngineProfile *profile) {
+  auto *scripts = profile->scripts();
+  const auto existing = scripts->find(QLatin1String(kScriptName));
+  for (const auto &script : existing)
+    scripts->remove(script);
+
+  QSettings &s = SettingsManager::instance().settings();
+  const bool dismiss =
+      s.value(QStringLiteral("webtweaks/dismissExpressionsPanel"), false).toBool();
+  if (!dismiss)
+    return; // nothing enabled → do not inject on fresh loads
+
+  QWebEngineScript script;
+  script.setName(QLatin1String(kScriptName));
+  script.setSourceCode(scriptSource());
+  script.setInjectionPoint(QWebEngineScript::DocumentReady);
+  script.setWorldId(QWebEngineScript::MainWorld);
+  script.setRunsOnSubFrames(false);
+  scripts->insert(script);
+}
+
+} // namespace WebTweaks

--- a/src/webtweaks.h
+++ b/src/webtweaks.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QString>
+#include <QWebEngineProfile>
+
+// Optional, user-toggleable JavaScript tweaks injected into WhatsApp Web to
+// adjust behaviors of the web app itself (settings group "webtweaks").
+// Every tweak is defensive: when WhatsApp Web changes its internals the tweak
+// silently stops matching instead of breaking the page.
+namespace WebTweaks {
+
+// The userscript, with the current QSettings baked into its FLAGS object.
+// Used both for profile injection (fresh page loads) and for applying a
+// toggle to an already-loaded page via QWebEnginePage::runJavaScript.
+QString scriptSource();
+
+// (Re)installs the userscript on the profile for FUTURE page loads according
+// to the current QSettings; removes it when nothing is enabled. Note: Qt does
+// not propagate profile-script changes to an already-created page, so callers
+// must also runJavaScript(scriptSource()) on the live page to apply a toggle
+// immediately.
+void install(QWebEngineProfile *profile);
+
+} // namespace WebTweaks


### PR DESCRIPTION
## Summary

WhatsApp Web keeps the expressions (emoji / GIF / sticker) panel open until its toolbar button is pressed again — clicking elsewhere does not dismiss it. This adds an **opt-in** General setting, **"Close emoji/sticker panel when clicking outside"** (off by default), that closes the panel when a `pointerdown` lands outside it.

Cross-platform; no platform-specific code.

## How it works

- A small userscript is injected into WhatsApp Web via `QWebEngineScript`. On an outside `pointerdown` it dispatches a synthetic `Escape` (the same key WhatsApp itself uses to close the panel).
- "Panel open" is detected structurally: the persistent `#expressions-panel-container` mount node has a child subtree only while the panel is open (the container itself always exists at height 0).
- The behavior is gated by a **live flag** on `window.__whatsieWebTweaks`, and `MainWindow` re-runs the script on the loaded page when the setting is toggled — so it applies immediately, without a reload. (Qt does not propagate `QWebEngineProfile` script-collection changes to an already-created page, even across a reload.)
- Every DOM access is wrapped in try/catch and tolerant selector checks, so if WhatsApp Web changes its internals the tweak silently degrades to a no-op instead of breaking the page.

## Testing

Built and exercised on Windows (Qt 6.11.1 / MSVC 2022): toggling the setting enables/disables the dismiss behavior instantly on the open page; with it off, WhatsApp's default (panel stays open) is unchanged. The code is platform-neutral Qt/QtWebEngine and does not touch any OS-specific paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)