### PR TITLE
Fix logout: app hangs on "Logging out" and WhatsApp Web opens in the default browser

### DIFF
--- a/src/webenginepage.cpp
+++ b/src/webenginepage.cpp
@@ -31,7 +31,12 @@ WebEnginePage::WebEnginePage(QWebEngineProfile *profile, QObject *parent)
 bool WebEnginePage::acceptNavigationRequest(const QUrl &url,
                                             QWebEnginePage::NavigationType type,
                                             bool isMainFrame) {
-  if (QWebEnginePage::NavigationType::NavigationTypeLinkClicked == type) {
+  // Open link clicks in the default browser — but only when they leave
+  // WhatsApp. The logout flow ends with a click-triggered navigation back to
+  // web.whatsapp.com; hijacking it opened a browser tab and left the app
+  // stuck on the "Logging out" overlay forever.
+  if (QWebEnginePage::NavigationType::NavigationTypeLinkClicked == type &&
+      url.host() != QLatin1String("web.whatsapp.com")) {
     QDesktopServices::openUrl(url);
     return false;
   }


### PR DESCRIPTION
### The bug
Logging out from WhatSie (profile menu → Log out) does two wrong things at once:

1. WhatsApp Web opens in the system's default browser, and
2. the app itself hangs forever on *"Logging out — Do not close this window"*.

### Cause
`WebEnginePage::acceptNavigationRequest()` opens **every** `NavigationTypeLinkClicked` navigation in the external browser and blocks it in-app — regardless of the target URL. WhatsApp Web's logout flow ends with a click-triggered navigation back to `web.whatsapp.com`, so that navigation gets shipped to the browser (symptom 1) while the page waits forever for a navigation that never happens (symptom 2).

### Fix
Only open link clicks externally when they actually leave `web.whatsapp.com`. External links in chats still open in the default browser exactly as before.

### Tested
On Linux (Qt 6.12 / Qt WebEngine): logout now completes in-app and lands on the QR screen; no browser tab opens; links to external sites still open in the default browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
