### PR TITLE
Identify as WhatSie in the phone's linked-devices list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCES
     src/common.cpp
     src/downloadmanagerwidget.cpp
     src/downloadwidget.cpp
+    src/linkeddevicename.cpp
     src/lock.cpp
     src/main.cpp
     src/identicons.cpp
@@ -123,6 +124,7 @@ set(HEADERS
     src/def.h
     src/downloadmanagerwidget.h
     src/downloadwidget.h
+    src/linkeddevicename.h
     src/lock.h
     src/identicons.h
     src/mainwindow.h

--- a/src/linkeddevicename.cpp
+++ b/src/linkeddevicename.cpp
@@ -1,0 +1,121 @@
+#include "linkeddevicename.h"
+#include "settingsmanager.h"
+
+#include <QWebEngineScript>
+#include <QWebEngineScriptCollection>
+
+static const char kScriptName[] = "whatsie-linked-device-name";
+
+// __NAME__ becomes a JS string literal ("WhatSie for Linux", or "" when the
+// setting is off). The label comes from WAWebBrowserInfo — a module whose
+// default export is a 0-arg function returning {os, name, version, ua} — so
+// the hook swaps the module registry's defaultExport for a decorating wrapper
+// (older WhatsApp Web builds exposed the same function as
+// WAWebMiscBrowserUtils.info; that path is kept as a fallback).
+//
+// The phone renders the label as "Browser (OS)", where the os field displays
+// arbitrary text but the browser name is validated against known browsers
+// and silently omitted otherwise (both behaviors observed by re-linking a
+// phone). The wrapper exploits that: os carries the full brand text and name
+// is set to the unrecognized "WhatSie", so the browser prefix disappears and
+// the label reads just "WhatSie for Linux".
+//
+// The wrapper reads the LIVE name from window.__whatsieLinkedDeviceName, so
+// re-running this script on a loaded page toggles the override without a
+// reload. The module system loads asynchronously, so the hook retries until
+// it resolves.
+static const char kScriptTemplate[] = R"JS(
+(function () {
+  'use strict';
+  var NAME = __NAME__;
+  window.__whatsieLinkedDeviceName = NAME;  // live value read by the wrapper
+  if (window.__whatsieLinkedDeviceNameHooked || !NAME) return;
+  var wrap = function (orig) {
+    return function () {
+      var inf = orig.apply(this, arguments);
+      try {
+        if (window.__whatsieLinkedDeviceName && inf) {
+          inf.os = window.__whatsieLinkedDeviceName;
+          inf.name = 'WhatSie';  // unknown browser → phone omits the prefix
+        }
+      } catch (e) { /* keep the stock label */ }
+      return inf;
+    };
+  };
+  var tries = 0;
+  var hook = function () {
+    if (window.__whatsieLinkedDeviceNameHooked) return;
+    try {
+      if (typeof window.require === 'function') {
+        // Current builds: bare-function module, patched via the registry.
+        var rec = window.require('__debug').modulesMap['WAWebBrowserInfo'];
+        if (rec && typeof rec.defaultExport === 'function') {
+          var wrapped = wrap(rec.defaultExport);
+          rec.defaultExport = wrapped;
+          if (rec.exports && typeof rec.exports.default === 'function')
+            rec.exports.default = wrapped;
+          window.__whatsieLinkedDeviceNameHooked = true;
+          return;
+        }
+        // Older builds: plain export on WAWebMiscBrowserUtils.
+        var mod = window.require('WAWebMiscBrowserUtils');
+        if (mod && typeof mod.info === 'function') {
+          mod.info = wrap(mod.info);
+          window.__whatsieLinkedDeviceNameHooked = true;
+          return;
+        }
+      }
+    } catch (e) { /* module not registered yet — retry */ }
+    if (++tries < 120) setTimeout(hook, 250);  // ~30s while the app boots
+  };
+  hook();
+})();
+)JS";
+
+namespace LinkedDeviceName {
+
+static QString platformDeviceName() {
+#if defined(Q_OS_WIN)
+  return QStringLiteral("WhatSie for Windows");
+#elif defined(Q_OS_MACOS)
+  return QStringLiteral("WhatSie for macOS");
+#else
+  return QStringLiteral("WhatSie for Linux");
+#endif
+}
+
+static bool isEnabled() {
+  return SettingsManager::instance()
+      .settings()
+      .value(QStringLiteral("identifyInLinkedDevices"), true)
+      .toBool();
+}
+
+QString scriptSource() {
+  const QString name = isEnabled() ? platformDeviceName() : QString();
+
+  QString source = QString::fromLatin1(kScriptTemplate);
+  source.replace(QLatin1String("__NAME__"),
+                 QStringLiteral("\"%1\"").arg(name));
+  return source;
+}
+
+void install(QWebEngineProfile *profile) {
+  auto *scripts = profile->scripts();
+  const auto existing = scripts->find(QLatin1String(kScriptName));
+  for (const auto &script : existing)
+    scripts->remove(script);
+
+  if (!isEnabled())
+    return; // disabled → do not inject on fresh loads
+
+  QWebEngineScript script;
+  script.setName(QLatin1String(kScriptName));
+  script.setSourceCode(scriptSource());
+  script.setInjectionPoint(QWebEngineScript::DocumentReady);
+  script.setWorldId(QWebEngineScript::MainWorld);
+  script.setRunsOnSubFrames(false);
+  scripts->insert(script);
+}
+
+} // namespace LinkedDeviceName

--- a/src/linkeddevicename.h
+++ b/src/linkeddevicename.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <QString>
+#include <QWebEngineProfile>
+
+// Makes new logins appear as "WhatSie for Linux" (or the matching platform)
+// in the phone's Linked-Devices list, instead of "Google Chrome (Linux)".
+//
+// WhatsApp Web derives that label client-side (the WAWebBrowserInfo module;
+// WAWebMiscBrowserUtils.info in older builds) and sends it to the phone while
+// a device is being linked, so a userscript that decorates the returned
+// browser info before the QR code is scanned is enough. The hook is
+// defensive: if WhatsApp Web renames its internals the script silently does
+// nothing and the label falls back to the stock one.
+//
+// The label is stored on the phone at link time; toggling the setting only
+// affects devices linked afterwards (settings key "identifyInLinkedDevices").
+namespace LinkedDeviceName {
+
+// The userscript with the current QSettings baked in. Used both for profile
+// injection (fresh page loads) and for applying a toggle to an already-loaded
+// page via QWebEnginePage::runJavaScript.
+QString scriptSource();
+
+// (Re)installs the userscript on the profile for FUTURE page loads according
+// to the current QSettings; removes it when disabled. Note: Qt does not
+// propagate profile-script changes to an already-created page, so callers
+// must also runJavaScript(scriptSource()) on the live page to apply a toggle
+// immediately.
+void install(QWebEngineProfile *profile);
+
+} // namespace LinkedDeviceName

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -11,6 +11,7 @@
 
 #include "about.h"
 #include "common.h"
+#include "linkeddevicename.h"
 #include "rateapp.h"
 #include "theme.h"
 #include "webengineprofilemanager.h"
@@ -228,6 +229,18 @@ void MainWindow::initSettingWidget() {
 
   connect(m_settingsWidget, &SettingsWidget::notify, m_settingsWidget,
           [=](QString message) { showNotification("", message); });
+
+  connect(m_settingsWidget, &SettingsWidget::linkedDeviceNameChanged,
+          m_settingsWidget, [=]() {
+            // Update the profile scripts for future page loads, and apply the
+            // change to the already-loaded page (Qt does not propagate profile
+            // script changes to an existing page).
+            LinkedDeviceName::install(
+                WebEngineProfileManager::instance().profile());
+            if (m_webEngine && m_webEngine->page())
+              m_webEngine->page()->runJavaScript(
+                  LinkedDeviceName::scriptSource());
+          });
 
   m_settingsWidget->appLockSetChecked(SettingsManager::instance()
                                           .settings()

--- a/src/settingswidget.cpp
+++ b/src/settingswidget.cpp
@@ -85,6 +85,11 @@ SettingsWidget::SettingsWidget(QWidget *parent, int screenNumber,
                                      .settings()
                                      .value("startMinimized", false)
                                      .toBool());
+  ui->identifyInLinkedDevicesCheckBox->setChecked(
+      SettingsManager::instance()
+          .settings()
+          .value("identifyInLinkedDevices", true)
+          .toBool());
 
   this->appAutoLockingSetChecked(
       SettingsManager::instance()
@@ -584,6 +589,12 @@ void SettingsWidget::on_useNativeFileDialog_toggled(bool checked) {
 
 void SettingsWidget::on_startMinimized_toggled(bool checked) {
   SettingsManager::instance().settings().setValue("startMinimized", checked);
+}
+
+void SettingsWidget::on_identifyInLinkedDevicesCheckBox_toggled(bool checked) {
+  SettingsManager::instance().settings().setValue("identifyInLinkedDevices",
+                                                  checked);
+  emit linkedDeviceNameChanged();
 }
 
 void SettingsWidget::on_appAutoLockcheckBox_toggled(bool checked) {

--- a/src/settingswidget.h
+++ b/src/settingswidget.h
@@ -22,6 +22,7 @@ signals:
   void userAgentChanged(QString userAgentStr);
   void initLock();
   void changeLockPassword();
+  void linkedDeviceNameChanged();
   void notificationPopupTimeOutChanged();
   void notify(QString message);
   void zoomChanged();
@@ -63,6 +64,7 @@ private slots:
   void on_chnageCurrentPasswordPushButton_clicked();
   void on_closeButtonActionComboBox_currentIndexChanged(int index);
   void on_defaultUserAgentButton_clicked();
+  void on_identifyInLinkedDevicesCheckBox_toggled(bool checked);
   void on_minimizeOnTrayIconClick_toggled(bool checked);
   void on_muteAudioCheckBox_toggled(bool checked);
   void on_notificationCheckBox_toggled(bool checked);

--- a/src/settingswidget.ui
+++ b/src/settingswidget.ui
@@ -358,6 +358,16 @@ background:transparent;
               </property>
              </widget>
             </item>
+            <item row="5" column="0" colspan="2">
+             <widget class="QCheckBox" name="identifyInLinkedDevicesCheckBox">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;New logins appear as &amp;quot;WhatSie for Linux&amp;quot; (or the matching platform) in your phone's linked-devices list instead of &amp;quot;Google Chrome (Linux)&amp;quot;. The name is stored on the phone when a device is linked, so changing this only affects future links — log out and re-link to rename an existing session.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Identify as WhatSie in linked devices</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item row="15" column="0">

--- a/src/webengineprofilemanager.cpp
+++ b/src/webengineprofilemanager.cpp
@@ -1,5 +1,6 @@
 #include "webengineprofilemanager.h"
 #include "common.h"
+#include "linkeddevicename.h"
 #include "settingsmanager.h"
 
 #include <QDebug>
@@ -88,4 +89,6 @@ void WebEngineProfileManager::applyUserSettings() {
     m_profile->settings()->setAttribute(
         QWebEngineSettings::PlaybackRequiresUserGesture,
         s.value(QStringLiteral("autoPlayMedia"), false).toBool());
+
+    LinkedDeviceName::install(m_profile);
 }


### PR DESCRIPTION
Sessions linked from WhatSie currently show up on the phone as a generic browser ("Google Chrome (Linux)"). This makes new logins appear as **"WhatSie for Linux"** (or the matching platform) instead — nice branding for the project and clearer for users with several linked devices.

### How it works
WhatsApp Web derives the linked-device label client-side (the `WAWebBrowserInfo` module; `WAWebMiscBrowserUtils.info` in older builds — the script handles both) and sends it to the phone at link time. A small userscript decorates the returned browser info before the QR is scanned. Same mechanism whatsapp-web.js merged in [wwebjs/whatsapp-web.js#3325](https://github.com/wwebjs/whatsapp-web.js/pull/3325).

The phone renders the label as "Browser (OS)" and validates the browser name against known browsers while displaying arbitrary OS text (both behaviors confirmed by linking a real phone), so the script puts the brand text in `os` and the unrecognized "WhatSie" in `name`, collapsing the label to just "WhatSie for Linux".

### Scope & safety
- New General setting *"Identify as WhatSie in linked devices"* gates it (default on — happy to flip the default if you prefer; it's one line).
- The label is stored on the phone at link time, so it only affects devices linked afterwards; toggling applies to the loaded page immediately.
- **Caveat, stated openly:** this patches WhatsApp Web internals, so a future Meta refactor can silently disable it — the hook then no-ops and the label falls back to the stock one; the page itself can never break. (This happened once during development — the function moved modules — which is why the script already handles both known layouts.)

Verified by linking a real phone: the device list shows "WhatSie for Linux".

*Note: this PR and #322 both add a checkbox to General settings; whichever merges second needs a trivial rebase — happy to do it.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
