### PR TITLE
fix: dark theme resetting to light across restarts

### DIFF
--- a/src/mainwindow_webengine.cpp
+++ b/src/mainwindow_webengine.cpp
@@ -368,7 +368,13 @@ QString MainWindow::getPageTheme() const {
         "  return v === 'dark' ? 'dark' : 'light';"
         "})();",
         [=](const QVariant &result) {
-          theme = result.toString() == "dark" ? "dark" : "light";
+          // On quit the page can be torn down before this JS completes; the
+          // callback then fires with an empty result. Persist only a definite
+          // answer, otherwise a dark preference gets overwritten with light.
+          const QString value = result.toString();
+          if (value != "dark" && value != "light")
+            return;
+          theme = value;
           SettingsManager::instance().settings().setValue("windowTheme", theme);
         });
   }


### PR DESCRIPTION
## Problem

Selecting the dark theme works during the session, but after quitting and starting again the app comes back in light mode - both the window chrome and WhatsApp Web itself. Reproduced on Linux Mint and on Windows (with the pending Windows port #321).

## Cause

On quit, `quitApp()`/`closeEvent()` call `getPageTheme()`, which reads the theme back from the page via `QWebEnginePage::runJavaScript()`. The page is usually destroyed before the script completes, and Qt then invokes the callback with an empty `QVariant`. The callback mapped every non-`"dark"` result to `"light"` and persisted it, so a dark `windowTheme` was overwritten with light on almost every quit. On the next launch `updatePageTheme()` then actively re-applies light to WhatsApp Web, clobbering the in-page preference as well.

Diagnosed on a live instance via the Chromium remote debugging protocol: with the page in dark mode (`localStorage['theme'] = 'dark'`), a real quit still wrote `windowTheme=light` to settings, while force-killing the process (skipping the quit path) preserved `dark`.

## Fix

Persist the read-back value only when it is a definite `"dark"` or `"light"`; otherwise keep the last saved preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)