### PR TITLE
fix: don't force --disable-gpu, it blanks video in calls

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,14 +11,21 @@
 #include <singleapplication.h>
 
 // Must run before QApplication is created so Qt WebEngine picks these up.
+//
+// Do NOT add --disable-gpu / --disable-gpu-compositing here.  Chromium ties
+// WebGL to the GPU process: with the GPU disabled there is no WebGL context at
+// all (software fallback via SwiftShader now needs an explicit
+// --enable-unsafe-swiftshader), and WhatsApp Web's call UI renders the remote
+// participant's video through WebGL.  The result is a call that connects, with
+// audio and a working self-preview, but a permanently blank remote video.
+// Users on broken drivers can still opt out by exporting
+// QTWEBENGINE_CHROMIUM_FLAGS themselves, which short-circuits this function.
 static void setChromiumFlags() {
   if (!qEnvironmentVariableIsEmpty("QTWEBENGINE_CHROMIUM_FLAGS"))
     return;
 #ifdef QT_DEBUG
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS",
     "--remote-debugging-port=9421 "
-          "--disable-gpu "
-          "--disable-gpu-compositing "
           "--disable-translate "
           "--disable-extensions "
           "--disable-component-update "
@@ -26,8 +33,6 @@ static void setChromiumFlags() {
           "--no-sandbox");
 #else
   qputenv("QTWEBENGINE_CHROMIUM_FLAGS",
-          "--disable-gpu "
-          "--disable-gpu-compositing "
           "--disable-translate "
           "--disable-extensions "
           "--disable-component-update "


### PR DESCRIPTION
The Qt 6.10 / CMake migration (60e689a) replaced --ignore-gpu-blocklist with --disable-gpu and --disable-gpu-compositing.

Chromium ties WebGL availability to the GPU process, and since M133 the SwiftShader software fallback is no longer used implicitly -- it needs an explicit --enable-unsafe-swiftshader. With the GPU process disabled the page therefore has no WebGL context at all:

    webgl: false, webgl2: false

WhatsApp Web renders the remote participant's stream through WebGL, while the local self-preview is a plain video element. The user-visible result is a video call that connects normally, with working audio but a permanently blank video.

Dropping the two flags restores WebGL:

    webgl: true, webgl2: true
    renderer: ANGLE (Intel, Mesa Intel(R) Graphics (MTL), OpenGL ES 3.2)

and the videos renders again.

Users on broken drivers who still need the GPU off can export QTWEBENGINE_CHROMIUM_FLAGS themselves; setChromiumFlags() returns early when that variable is already set, so the escape hatch is preserved.

Tested on openSUSE Tumbleweed with qt6-webengine 6.11.1 on Intel Meteor Lake graphics.