### PR TITLE
fix: restore the window from the tray when the WM minimized it

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -328,14 +328,7 @@ void MainWindow::showNotification(QString title, QString message) {
   }
 }
 
-void MainWindow::notificationClicked() {
-  show();
-  QCoreApplication::processEvents();
-  if (windowState().testFlag(Qt::WindowMinimized))
-    setWindowState(windowState() & ~Qt::WindowMinimized);
-  raise();
-  activateWindow();
-}
+void MainWindow::notificationClicked() { restoreWindow(); }
 
 // ── Lifecycle events ──────────────────────────────────────────────────────────
 
@@ -386,8 +379,7 @@ void MainWindow::alreadyRunning(bool notify) {
   if (notify)
     showNotification(QApplication::applicationName(),
                      "Restored an already running instance.");
-  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
-  show();
+  restoreWindow();
 }
 
 // ── Dialogs ───────────────────────────────────────────────────────────────────

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -27,6 +27,7 @@ public:
                 bool byLoadingQuirk = false);
 
 public slots:
+  void restoreWindow();
   void updateWindowTheme();
   void updatePageTheme();
   void handleWebViewTitleChanged(const QString &title);
@@ -67,6 +68,7 @@ private:
   void initAutoLock();
   void triggerNewChat(const QString &phone, const QString &text);
   void restoreMainWindow();
+  bool isWindowShown() const;
 
   Notification::Manager m_notifier;
   QIcon m_trayIconNormal;

--- a/src/mainwindow_tray.cpp
+++ b/src/mainwindow_tray.cpp
@@ -4,8 +4,17 @@
 
 #include <algorithm>
 
+#include <QGuiApplication>
 #include <QShortcut>
 #include <QStyleHints>
+#include <QWindow>
+
+#if __has_include(<QtGui/qguiapplication_platform.h>)
+#include <QtGui/qguiapplication_platform.h>
+#endif
+
+#include <X11/Xatom.h> // keep the X11 headers at the bottom, they define
+#include <X11/Xlib.h>  // None, Status and Bool as macros
 
 // ── Actions ──────────────────────────────────────────────────────────────────
 
@@ -30,7 +39,8 @@ void MainWindow::createActions() {
   minimizeShortcut->setAutoRepeat(false);
 
   m_restoreAction = new QAction(tr("&Restore"), this);
-  connect(m_restoreAction, &QAction::triggered, this, &QMainWindow::show);
+  connect(m_restoreAction, &QAction::triggered, this,
+          &MainWindow::restoreWindow);
   addAction(m_restoreAction);
 
   m_reloadAction = new QAction(tr("Re&load"), this);
@@ -100,34 +110,113 @@ void MainWindow::createTrayIcon() {
   }
 }
 
-void MainWindow::checkWindowState() {
-  QObject *tray_icon_menu = this->findChild<QObject *>("trayIconMenu");
-  if (tray_icon_menu == nullptr)
-    return;
+// ── Window visibility ─────────────────────────────────────────────────────────
 
-  QMenu *menu = qobject_cast<QMenu *>(tray_icon_menu);
-  if (this->isVisible()) {
-    menu->actions().at(0)->setDisabled(false);
-    menu->actions().at(1)->setDisabled(true);
-  } else {
-    menu->actions().at(0)->setDisabled(true);
-    menu->actions().at(1)->setDisabled(false);
-  }
-  menu->actions().at(4)->setDisabled(m_lockWidget && m_lockWidget->getIsLocked());
+namespace {
+
+// Whether the window manager currently keeps the window off screen.
+//
+// Qt derives Qt::WindowMinimized from WM_STATE only, but a window manager is
+// free to minimize a window without ever setting WM_STATE to Iconic. KWin on
+// X11 does exactly that: it sets _NET_WM_STATE_HIDDEN and leaves the window
+// mapped with WM_STATE at Normal, so the application keeps reporting a visible,
+// non-minimized, still exposed window that the user cannot see anywhere.
+// Reading the property the window manager itself sets is the only way to tell.
+bool windowIsHiddenByWM(WId window) {
+#if defined(Q_OS_UNIX) && __has_include(<QtGui/qguiapplication_platform.h>)
+  const auto *x11 =
+      qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
+  if (x11 == nullptr || window == 0)
+    return false;
+
+  Display *display = x11->display();
+  const Atom netWmState = XInternAtom(display, "_NET_WM_STATE", True);
+  const Atom hiddenState = XInternAtom(display, "_NET_WM_STATE_HIDDEN", True);
+  if (netWmState == None || hiddenState == None)
+    return false;
+
+  Atom type = None;
+  int format = 0;
+  unsigned long stateCount = 0, bytesAfter = 0;
+  unsigned char *data = nullptr;
+  if (XGetWindowProperty(display, window, netWmState, 0, 32, False, XA_ATOM,
+                         &type, &format, &stateCount, &bytesAfter,
+                         &data) != Success ||
+      data == nullptr)
+    return false;
+
+  const Atom *states = reinterpret_cast<Atom *>(data);
+  bool hidden = false;
+  for (unsigned long i = 0; i < stateCount && !hidden; ++i)
+    hidden = states[i] == hiddenState;
+
+  XFree(data);
+  return hidden;
+#else
+  Q_UNUSED(window)
+  return false;
+#endif
+}
+
+} // namespace
+
+// Whether the main window is actually on screen for the user.
+//
+// QWidget::isVisible() alone does not answer that: a window minimized by the
+// window manager stays "visible" for Qt, and so does QWindow::isExposed() when
+// the window manager keeps the window mapped while minimizing it. Ask the
+// window manager on top of Qt's own state.
+bool MainWindow::isWindowShown() const {
+  if (isHidden() || isMinimized())
+    return false;
+
+  const QWindow *handle = windowHandle();
+  if (handle == nullptr || !handle->isExposed())
+    return false;
+
+  return !windowIsHiddenByWM(winId());
+}
+
+void MainWindow::restoreWindow() {
+  // A window the window manager minimized behind Qt's back is still "shown" as
+  // far as Qt is concerned, which makes show() a no-op and would leave the
+  // window off screen. Re-mapping it is the one way back that works on every
+  // window manager.
+  if (!isWindowShown() && isVisible())
+    hide();
+
+  setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+  show();
+  raise();
+  activateWindow();
+  if (QWindow *handle = windowHandle())
+    handle->requestActivate();
+}
+
+void MainWindow::checkWindowState() {
+  const bool shown = isWindowShown();
+  m_minimizeAction->setDisabled(!shown);
+  m_restoreAction->setDisabled(shown);
+  m_lockAction->setDisabled(m_lockWidget && m_lockWidget->getIsLocked());
 }
 
 void MainWindow::iconActivated(QSystemTrayIcon::ActivationReason reason) {
-  if (SettingsManager::instance()
-              .settings()
-              .value("minimizeOnTrayIconClick", false)
-              .toBool() == false ||
-      reason == QSystemTrayIcon::Context)
+  if (reason != QSystemTrayIcon::Trigger &&
+      reason != QSystemTrayIcon::DoubleClick)
     return;
-  if (isVisible()) {
+
+  // Hiding the window on a tray click stays opt-in, restoring it never is:
+  // clicking the tray icon of a window the user cannot see has to bring that
+  // window back, the way every other tray application behaves.
+  const bool minimizeOnClick = SettingsManager::instance()
+                                   .settings()
+                                   .value("minimizeOnTrayIconClick", false)
+                                   .toBool();
+  if (minimizeOnClick && isWindowShown()) {
     hide();
-  } else {
-    show();
+    return;
   }
+  restoreWindow();
 }
 
 const QIcon MainWindow::getTrayIcon(const int &notificationCount) const {


### PR DESCRIPTION
### Problem

Once the main window is minimized, there is no way back to it from the tray:

- the tray menu still offers **Minimize to tray** and keeps **Restore** greyed out
- clicking the tray icon does nothing at all

Reported in #292 ("My restore option is always grey", Fedora/Wayland) and #274 ("Clicking on the tray icon does nothing. I have to right-click the icon and select Restore", Fedora KDE, RHEL, CachyOS). Reproduced here on KDE Plasma 6 / X11 with the 5.1.0 Flatpak.

### Cause 1 — the window state is read from `isVisible()`

`checkWindowState()` decided on `QWidget::isVisible()`. A window minimized by the window manager stays *visible* for Qt, and a window manager is free to minimize without ever setting `WM_STATE` to `Iconic` — which is the only source Qt derives `Qt::WindowMinimized` from. KWin on X11 sets `_NET_WM_STATE_HIDDEN` and leaves the window mapped with `WM_STATE` at `Normal`.

Measured while KWin had the window minimized:

```
WM:  _NET_WM_STATE = _NET_WM_STATE_MAXIMIZED_VERT, _NET_WM_STATE_MAXIMIZED_HORZ, _NET_WM_STATE_HIDDEN
     WM_STATE = Normal      Map State = IsViewable

Qt:  visible=true  hidden=false  minimized=false  exposed=true  visibility=Maximized
```

Every Qt-level signal reports a window that is on screen, including `QWindow::isExposed()`. So the menu enabled *Minimize to tray* and disabled *Restore* for a window the user could not see.

### Cause 2 — tray clicks were dropped before they could restore

`iconActivated()` returned early unless `minimizeOnTrayIconClick` was enabled. That setting defaults to `false`, so single and double clicks on the tray icon never reached any restore logic. With the setting enabled it branched on the same `isVisible()` and would `hide()` an already minimized window.

### Change

- `isWindowShown()` asks the window manager for `_NET_WM_STATE_HIDDEN` on top of Qt's own state. `libX11` is already linked, and the query uses the display Qt owns via `QNativeInterface::QX11Application`; off X11 it falls back to Qt's state.
- `restoreWindow()` becomes the single restore path used by the tray menu, tray click, notification click and second-instance launch, which previously each did something slightly different. It re-maps the window when the window manager hid it behind Qt's back, because `show()` is a no-op for a window Qt believes is already showing, then clears `WindowMinimized`, raises and activates it.
- Tray clicks always restore. Only the hide-on-click half stays behind `minimizeOnTrayIconClick`, matching what the setting is named after.
- `checkWindowState()` uses the action pointers instead of `menu->actions().at(0|1|4)`, so inserting a menu entry cannot silently disable the wrong action.

No new dependency, no settings change, no behaviour change for users who had `minimizeOnTrayIconClick` enabled.

### Verification

Built as the Flathub Flatpak (`org.kde.Sdk` 6.11, `io.qt.qtwebengine.BaseApp` 6.11) and driven over D-Bus on KDE Plasma 6 / X11 — the menu states below are read from the DBusMenu export, i.e. exactly what Plasma renders:

| Scenario | Menu state | Tray click |
|---|---|---|
| Window shown | Minimize enabled, Restore disabled | — |
| Minimized via titlebar button | Minimize disabled, Restore enabled | restores and focuses (`_NET_WM_STATE_FOCUSED`) |
| Closed to tray | Minimize disabled, Restore enabled | restores, maximized state preserved |

Before the change, both minimized cases showed *Minimize to tray* enabled with *Restore* greyed out, and the tray click did nothing.

I could only test X11. The dropped tray click of #274 was platform independent and is fixed either way, but the greyed out *Restore* of #292 was verified on X11 only: on Wayland the restore itself works, while the menu state falls back to what Qt reports for a compositor minimized window, which I have no way to check here. Confirmation from a Wayland user would be welcome before treating that half as done.

Closes #274
Refs #292
