### PR TITLE
feat(web): add a JavaScript memory limit to bound WhatsApp Web's heap

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -164,7 +164,8 @@ void Application::applyChromiumFlags()
     // Must happen before the first QWebEngineProfile is created (FEATURES P6).
     evaluateGpuStability();
     const QString existing = qEnvironmentVariable("QTWEBENGINE_CHROMIUM_FLAGS");
-    QStringList ours = core::chromiumFlags(m_settings->hardwareAcceleration(), m_settings->gpuAutoDisabled());
+    QStringList ours = core::chromiumFlags(m_settings->hardwareAcceleration(), m_settings->gpuAutoDisabled(),
+                                           m_settings->jsMemoryLimitMb());
     // In a snap we pass --no-sandbox here (isolation comes from snap confinement,
     // ADR-008) rather than hard-coding it in the snap's environment: — that let
     // it override the user's QTWEBENGINE_CHROMIUM_FLAGS and blocked the expert

--- a/src/core/chromium_flags.cpp
+++ b/src/core/chromium_flags.cpp
@@ -21,7 +21,7 @@ bool useSoftwareGpu(HardwareAcceleration acceleration, bool autoDisabled)
     return autoDisabled;
 }
 
-QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled)
+QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled, int jsMemoryLimitMb)
 {
     QStringList flags{
         // Nothing here is a chat client's business.
@@ -66,6 +66,15 @@ QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisable
         flags << u"--disable-gpu"_s;
     } else if (acceleration == HardwareAcceleration::On) {
         flags << u"--ignore-gpu-blocklist"_s;
+    }
+    // Bound WhatsApp Web's V8 heap so a long-running session cannot thrash into
+    // an out-of-memory abort. A hard cap when the user sets one, otherwise ask V8
+    // to trim its baseline heap. Packed into one --js-flags token (Qt splits the
+    // env var on spaces). Expert override: set QTWEBENGINE_CHROMIUM_FLAGS.
+    if (jsMemoryLimitMb > 0) {
+        flags << u"--js-flags=--max-old-space-size=%1"_s.arg(jsMemoryLimitMb);
+    } else {
+        flags << u"--js-flags=--optimize-for-size"_s;
     }
     return flags;
 }

--- a/src/core/chromium_flags.h
+++ b/src/core/chromium_flags.h
@@ -16,7 +16,8 @@ enum class HardwareAcceleration;
 /// value of that variable is kept and ours are appended. When the GPU is off
 /// (see useSoftwareGpu) it also enables SwiftShader so WhatsApp calls keep a
 /// software WebGL context instead of a blank remote video (ADR-032).
-[[nodiscard]] QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled = false);
+[[nodiscard]] QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled = false,
+                                        int jsMemoryLimitMb = 0);
 
 /// Merges `userFlags` (existing env var content) with ours, deduplicated.
 [[nodiscard]] QString mergeChromiumFlags(const QString& userFlags, const QStringList& ours);

--- a/src/core/settings/settings.cpp
+++ b/src/core/settings/settings.cpp
@@ -37,6 +37,7 @@ constexpr int kDefaultMessageBlurLevel = 0;
 constexpr bool kDefaultAskWhereToSave = false;
 constexpr bool kDefaultShowDownloadsOnStart = true;
 constexpr HardwareAcceleration kDefaultHardwareAcceleration = HardwareAcceleration::Auto;
+constexpr int kDefaultJsMemoryLimitMb = 0;
 constexpr bool kDefaultWebrtcPublicOnly = false;
 constexpr bool kDefaultSpellCheckEnabled = true;
 constexpr bool kDefaultLockOnStart = false;
@@ -419,6 +420,22 @@ void Settings::setHardwareAcceleration(HardwareAcceleration mode)
     setGpuAutoDisabled(false);
     setGpuProbeStrikes(0);
     Q_EMIT hardwareAccelerationChanged(mode);
+}
+
+int Settings::jsMemoryLimitMb() const
+{
+    const int stored = m_store->value(keys::kJsMemoryLimitMb, kDefaultJsMemoryLimitMb).toInt();
+    return stored <= 0 ? 0 : std::clamp(stored, kMinJsMemoryLimitMb, kMaxJsMemoryLimitMb);
+}
+
+void Settings::setJsMemoryLimitMb(int mb)
+{
+    const int clamped = mb <= 0 ? 0 : std::clamp(mb, kMinJsMemoryLimitMb, kMaxJsMemoryLimitMb);
+    if (clamped == jsMemoryLimitMb()) {
+        return;
+    }
+    m_store->setValue(keys::kJsMemoryLimitMb, clamped);
+    Q_EMIT jsMemoryLimitMbChanged(clamped);
 }
 
 bool Settings::webrtcPublicInterfacesOnly() const

--- a/src/core/settings/settings.h
+++ b/src/core/settings/settings.h
@@ -155,6 +155,13 @@ public:
     // advanced/
     [[nodiscard]] HardwareAcceleration hardwareAcceleration() const;
     void setHardwareAcceleration(HardwareAcceleration mode);
+    /// V8 JavaScript heap cap in MB; 0 = automatic (ask V8 to optimize for size).
+    /// Bounds WhatsApp Web's memory so a long-running session cannot thrash into
+    /// an out-of-memory abort. Applied to the Chromium flags at startup.
+    [[nodiscard]] int jsMemoryLimitMb() const;
+    void setJsMemoryLimitMb(int mb);
+    static constexpr int kMinJsMemoryLimitMb = 256;
+    static constexpr int kMaxJsMemoryLimitMb = 8192;
     /// FEATURES P2: force WebRTC onto public interfaces only (privacy; can break
     /// LAN calls). Default off.
     [[nodiscard]] bool webrtcPublicInterfacesOnly() const;
@@ -239,6 +246,7 @@ Q_SIGNALS:
     void askWhereToSaveChanged(bool ask);
     void showDownloadsOnStartChanged(bool show);
     void hardwareAccelerationChanged(whatsie::core::HardwareAcceleration mode);
+    void jsMemoryLimitMbChanged(int mb);
 
 private:
     [[nodiscard]] bool boolValue(QLatin1StringView key, bool def) const;

--- a/src/core/settings/settings_keys.h
+++ b/src/core/settings/settings_keys.h
@@ -68,6 +68,8 @@ inline constexpr QLatin1StringView kGpuAutoDisabled{"advanced/gpuAutoDisabled"};
 inline constexpr QLatin1StringView kGpuProbeStrikes{"advanced/gpuProbeStrikes"};
 // Set when the GPU was auto-disabled, so the next launch can tell the user why.
 inline constexpr QLatin1StringView kGpuFallbackNotice{"advanced/gpuFallbackNotice"};
+// V8 JavaScript heap cap in MB; 0 = automatic. Bounds WhatsApp Web's memory.
+inline constexpr QLatin1StringView kJsMemoryLimitMb{"advanced/jsMemoryLimitMb"};
 
 // proxy/ (password is deliberately NOT a key — never persisted)
 inline constexpr QLatin1StringView kProxyMode{"proxy/mode"};

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -488,6 +488,17 @@ QWidget* SettingsDialog::buildAdvancedTab()
             static_cast<HardwareAcceleration>(m_hardwareAcceleration->itemData(index).toInt()));
     });
     aform->addRow(tr("Hardware acceleration:"), m_hardwareAcceleration);
+    m_jsMemoryLimit = new QSpinBox(advBox);
+    m_jsMemoryLimit->setRange(0, core::Settings::kMaxJsMemoryLimitMb);
+    m_jsMemoryLimit->setSingleStep(256);
+    m_jsMemoryLimit->setSpecialValueText(tr("Automatic"));
+    m_jsMemoryLimit->setSuffix(tr(" MB"));
+    m_jsMemoryLimit->setToolTip(tr("Cap WhatsApp Web's JavaScript memory so a long session cannot "
+                                   "grow without bound. 0 = automatic; lower it if the app uses too "
+                                   "much RAM."));
+    connect(m_jsMemoryLimit, &QSpinBox::valueChanged, this,
+            [this](int mb) { m_settings.setJsMemoryLimitMb(mb); });
+    aform->addRow(tr("JavaScript memory limit:"), m_jsMemoryLimit);
     m_webrtcPublicOnly = new QCheckBox(tr("Route WebRTC through public interfaces only"), advBox);
     m_webrtcPublicOnly->setToolTip(tr("Hides local network addresses from calls. May break calls "
                                       "on some networks. Takes effect after a reload."));
@@ -694,6 +705,7 @@ void SettingsDialog::loadValues()
     m_notificationTimeout->setEnabled(m_settings.notificationsEnabled());
     m_hardwareAcceleration->setCurrentIndex(
         m_hardwareAcceleration->findData(static_cast<int>(m_settings.hardwareAcceleration())));
+    m_jsMemoryLimit->setValue(m_settings.jsMemoryLimitMb());
     m_spellCheck->setChecked(m_settings.spellCheckEnabled());
     if (m_spellLanguage != nullptr) {
         const QStringList available =

--- a/src/ui/settings_dialog.h
+++ b/src/ui/settings_dialog.h
@@ -91,6 +91,7 @@ private:
     QCheckBox* m_notificationSound = nullptr;
     QSpinBox* m_notificationTimeout = nullptr;
     QComboBox* m_hardwareAcceleration = nullptr;
+    QSpinBox* m_jsMemoryLimit = nullptr;
     QCheckBox* m_spellCheck = nullptr;
     QComboBox* m_spellLanguage = nullptr;
     QLabel* m_lockStatus = nullptr;

--- a/tests/tst_storage_and_flags.cpp
+++ b/tests/tst_storage_and_flags.cpp
@@ -110,6 +110,16 @@ private Q_SLOTS:
 #endif
     }
 
+    void jsMemoryLimitFlag()
+    {
+        // Automatic (0) trims the baseline heap; a positive value hard-caps it.
+        QVERIFY(chromiumFlags(HardwareAcceleration::Auto, false, 0)
+                    .contains(u"--js-flags=--optimize-for-size"_s));
+        const QStringList capped = chromiumFlags(HardwareAcceleration::Auto, false, 1024);
+        QVERIFY(capped.contains(u"--js-flags=--max-old-space-size=1024"_s));
+        QVERIFY(!capped.contains(u"--js-flags=--optimize-for-size"_s));
+    }
+
     void userFlagsAreKeptAndDeduplicated()
     {
         const QString merged =


### PR DESCRIPTION
A long-running WhatsApp Web session can grow V8's heap until it thrashes GC and aborts with an out-of-memory SIGABRT (issue #185). Add a "JavaScript memory limit" setting (Settings -> Advanced): 0 = automatic, which asks V8 to trim its baseline heap (--optimize-for-size); a positive value hard-caps it (--js-flags=--max-old-space-size=<MB>) so memory stays bounded. Applied to the Chromium flags at startup, like the hardware-acceleration setting; takes effect after a restart.

Refs: #185