### PR TITLE
feat(web): open WhatsApp group-invite links in the join preview

### DIFF
--- a/src/core/navigation_policy.cpp
+++ b/src/core/navigation_policy.cpp
@@ -1,5 +1,6 @@
 #include "core/navigation_policy.h"
 
+#include <QRegularExpression>
 #include <QUrlQuery>
 
 using namespace Qt::StringLiterals;
@@ -112,6 +113,29 @@ std::optional<NewChatRequest> parseChatLink(const QString& urlOrPhone)
         return std::nullopt;
     }
     return NewChatRequest{.phone = digits, .text = {}};
+}
+
+QString inviteCodeFromUrl(const QString& link)
+{
+    const QString trimmed = link.trimmed();
+    // A web invite link: https://chat.whatsapp.com/<code> (older links add an
+    // extra /invite/ segment). Checked first so it wins regardless of scheme.
+    static const QRegularExpression web(u"chat\\.whatsapp\\.com/(?:invite/)?([A-Za-z0-9._-]+)"_s);
+    QRegularExpressionMatch m = web.match(trimmed);
+    if (m.hasMatch()) {
+        return m.captured(1);
+    }
+    // The deep link the x-scheme-handler delivers: whatsapp://chat?code=<code>.
+    // Scoped to the "chat" action so a whatsapp://send request whose text happens
+    // to contain "code=" can never be mistaken for an invite.
+    if (trimmed.startsWith(u"whatsapp://chat"_s, Qt::CaseInsensitive)) {
+        static const QRegularExpression codeParam(u"[?&]code=([A-Za-z0-9._-]+)"_s);
+        m = codeParam.match(trimmed);
+        if (m.hasMatch()) {
+            return m.captured(1);
+        }
+    }
+    return {};
 }
 
 QUrl newChatUrl(const NewChatRequest& request)

--- a/src/core/navigation_policy.h
+++ b/src/core/navigation_policy.h
@@ -37,6 +37,11 @@ struct NewChatRequest
 [[nodiscard]] std::optional<NewChatRequest> parseChatLink(const QUrl& url);
 [[nodiscard]] std::optional<NewChatRequest> parseChatLink(const QString& urlOrPhone);
 
+/// The group-invite code from a link, or empty when it is not an invite:
+/// https://chat.whatsapp.com/[invite/]<code> or whatsapp://chat?code=<code>.
+/// A send link (whatsapp://send, wa.me, ...) or a phone number returns empty.
+[[nodiscard]] QString inviteCodeFromUrl(const QString& link);
+
 /// https://web.whatsapp.com/send?phone=<digits>&text=<encoded>
 [[nodiscard]] QUrl newChatUrl(const NewChatRequest& request);
 

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -392,6 +392,14 @@ void MainWindow::openChat(const QString& target)
         showAndRaise();
         return;
     }
+    // A group-invite link opens WhatsApp Web's "Join group" preview (issue #186);
+    // checked before the send-link parse so an invite is never treated as a send.
+    const QString invite = core::inviteCodeFromUrl(target);
+    if (!invite.isEmpty()) {
+        showAndRaise();
+        m_webView->openGroupInvite(invite);
+        return;
+    }
     const auto request = core::parseChatLink(target);
     if (!request) {
         qCWarning(lcUi) << "not a chat link or phone number:" << target;

--- a/src/web/web_view.cpp
+++ b/src/web/web_view.cpp
@@ -88,6 +88,7 @@ WebView::WebView(core::Settings& settings, core::ThemeService& theme, QWidget* p
             m_crashPolicy.onLoadSucceeded();
             applyBlurLive();
             applyThemeLive();
+            flushPendingInvite();
         }
     });
     // Replace Chromium's stock error page (disabled in the profile) with our own.
@@ -385,6 +386,48 @@ void WebView::openChat(const core::NewChatRequest& request)
     const QUrl target = core::newChatUrl(request);
     qCInfo(lcWeb) << "open chat" << target.toString(QUrl::RemoveQuery) << "phone=" << request.phone;
     load(target);
+}
+
+void WebView::openGroupInvite(const QString& code)
+{
+    if (code.isEmpty()) {
+        return;
+    }
+    m_pendingInvite = code;
+    flushPendingInvite();
+}
+
+void WebView::flushPendingInvite()
+{
+    // Only meaningful once WhatsApp Web itself is loaded — its click handler must
+    // exist to turn the synthetic click into a "Join group" preview. Until then
+    // the code stays pending and is flushed from loadFinished.
+    if (m_pendingInvite.isEmpty() || m_showingError || !core::isWhatsAppWebUrl(url())) {
+        return;
+    }
+    const QString code = m_pendingInvite;
+    m_pendingInvite.clear();
+    qCInfo(lcWeb) << "opening group invite";
+    // WhatsApp Web only opens a group invite when a chat.whatsapp.com link is
+    // clicked inside the page; navigating there does nothing. So synthesise a
+    // hidden link and click it. The code is validated to [A-Za-z0-9._-] by
+    // core::inviteCodeFromUrl, so embedding it in the script is safe.
+    static const QString kInviteScript = uR"JS(
+(function () {
+    function go() {
+        if (!document.body) { setTimeout(go, 100); return; }
+        var a = document.createElement('a');
+        a.href = 'https://chat.whatsapp.com/%1';
+        a.rel = 'noopener';
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+        setTimeout(function () { a.remove(); }, 0);
+    }
+    go();
+})();
+)JS"_s;
+    m_page->runJavaScript(kInviteScript.arg(code));
 }
 
 QString WebView::userAgent() const

--- a/src/web/web_view.h
+++ b/src/web/web_view.h
@@ -38,6 +38,9 @@ public:
     void loadWhatsApp();
     /// Opens a chat via https://web.whatsapp.com/send?phone=… (FEATURES S10).
     void openChat(const core::NewChatRequest& request);
+    /// Opens WhatsApp Web's "Join group" preview for an invite code (issue #186).
+    /// Deferred until the page has loaded if it is not ready yet.
+    void openGroupInvite(const QString& code);
 
     /// Selects which zoom setting applies (normal vs maximized/fullscreen).
     void setZoomMode(bool maximized);
@@ -84,6 +87,7 @@ private:
     void checkWatchdog();
     void applyBlurLive();
     void applyThemeLive();
+    void flushPendingInvite();
     void handleProxyAuth(QAuthenticator* authenticator, const QString& proxyHost);
     bool maybeHandleDrop(class QObject* watched, class QEvent* event);
     void handleFileDrop(const QStringList& paths);
@@ -104,6 +108,8 @@ private:
     bool m_showingError = false;
     QString m_errorTitle;
     QString m_errorDetail;
+    // A group-invite code awaiting a loaded WhatsApp Web page (issue #186).
+    QString m_pendingInvite;
 };
 
 } // namespace whatsie::web

--- a/tests/tst_navigation_policy.cpp
+++ b/tests/tst_navigation_policy.cpp
@@ -111,6 +111,21 @@ private Q_SLOTS:
         QVERIFY(parsed.has_value());
         QCOMPARE(*parsed, request);
     }
+
+    void parsesGroupInviteCodes()
+    {
+        QCOMPARE(inviteCodeFromUrl(u"https://chat.whatsapp.com/AbC123_-.xy"_s), u"AbC123_-.xy"_s);
+        QCOMPARE(inviteCodeFromUrl(u"https://chat.whatsapp.com/invite/AbC123"_s), u"AbC123"_s);
+        QCOMPARE(inviteCodeFromUrl(u"  chat.whatsapp.com/Zz99  "_s), u"Zz99"_s); // trimmed, no scheme
+        QCOMPARE(inviteCodeFromUrl(u"whatsapp://chat?code=Kk77"_s), u"Kk77"_s);
+        QCOMPARE(inviteCodeFromUrl(u"whatsapp://chat?foo=1&code=Kk77"_s), u"Kk77"_s);
+        // Not invites: send links, plain numbers, a send whose text mentions code=.
+        QVERIFY(inviteCodeFromUrl(u"whatsapp://send?phone=15551234"_s).isEmpty());
+        QVERIFY(inviteCodeFromUrl(u"whatsapp://send?text=code=NOTACODE"_s).isEmpty());
+        QVERIFY(inviteCodeFromUrl(u"https://wa.me/15551234"_s).isEmpty());
+        QVERIFY(inviteCodeFromUrl(u"+1 555 1234"_s).isEmpty());
+        QVERIFY(inviteCodeFromUrl(QString()).isEmpty());
+    }
 };
 
 QTEST_GUILESS_MAIN(TestNavigationPolicy)


### PR DESCRIPTION
Opens a WhatsApp **group-invite link** in WhatsApp Web's "Join group" preview instead of doing nothing / opening the system browser.

Closes #186

### How
- `core::inviteCodeFromUrl` parses the code from `https://chat.whatsapp.com/[invite/]<code>` and `whatsapp://chat?code=<code>`, and returns empty for send-links / phone numbers (unit-tested).
- `MainWindow::openChat` checks it **before** the send-link parse, so invites arriving via the `whatsapp://` scheme handler or `--new-chat` take the invite path.
- `WebView::openGroupInvite` synthesises a hidden `chat.whatsapp.com` link and clicks it — WhatsApp Web only opens an invite on an in-page click, not on navigation. The injection is **deferred to `loadFinished`** so a cold launch from an invite isn't lost.

### Notes
- Skips an `acceptNavigationRequest` guard by design: WhatsApp handles in-page invite clicks itself, and intercepting our own synthetic click would loop when logged out.
- Needs a live check with a real invite + logged-in session.

Refs: #186