### PR TITLE
fix: tray tooltip, drag-and-drop robustness, and arch diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(whatsie
-    VERSION 6.0.2
+    VERSION 6.0.3
     DESCRIPTION "WhatsApp Web desktop client built with Qt WebEngine"
     HOMEPAGE_URL "https://github.com/keshavbhatt/whatsie"
     LANGUAGES CXX

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+whatsie (6.0.3) unstable; urgency=medium
+
+  * Drag-and-drop: show a drop hint and report files that can't be attached
+    instead of failing silently.
+  * Tray tooltip now reads "Whatsie".
+  * Bug-report diagnostics include the CPU architecture.
+
+ -- Keshav Bhatt <keshavnrj@gmail.com>  Sat, 05 Sep 2026 12:00:00 +0530
+
 whatsie (6.0.1) unstable; urgency=medium
 
   * Debian packaging for the Qt 6 rewrite.

--- a/dist/linux/com.ktechpit.whatsie.metainfo.xml
+++ b/dist/linux/com.ktechpit.whatsie.metainfo.xml
@@ -102,6 +102,16 @@
   </content_rating>
 
   <releases>
+    <release version="6.0.3" date="2026-09-05">
+      <description>
+        <p>Fixes and small improvements:</p>
+        <ul>
+          <li>Drag-and-drop now shows a "Drop files to send" hint and, when a file can't be attached, explains why instead of doing nothing</li>
+          <li>The system-tray tooltip now reads "Whatsie"</li>
+          <li>Bug-report diagnostics include the CPU architecture</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.0.2" date="2026-09-04">
       <description>
         <p>Feature and fix release:</p>

--- a/src/platform/platform_info.cpp
+++ b/src/platform/platform_info.cpp
@@ -14,6 +14,7 @@ QString describeHost()
 {
     QStringList parts;
     parts << QSysInfo::prettyProductName();
+    parts << u"arch: %1"_s.arg(QSysInfo::currentCpuArchitecture());
     parts << u"Qt %1 (built against %2)"_s.arg(QString::fromLatin1(qVersion()),
                                                QLibraryInfo::version().toString());
     if (QGuiApplication::instance() != nullptr) {

--- a/src/ui/tray_controller.cpp
+++ b/src/ui/tray_controller.cpp
@@ -219,7 +219,7 @@ void TrayController::updateTooltip()
     if (m_tray == nullptr) {
         return;
     }
-    QStringList parts{u"WhatsApp"_s};
+    QStringList parts{u"Whatsie"_s};
     if (m_unread > 0) {
         parts << tr("%n unread", nullptr, m_unread);
     }

--- a/src/web/file_drop.cpp
+++ b/src/web/file_drop.cpp
@@ -23,17 +23,26 @@ DropOutcome buildDropPayload(const QStringList& paths, qint64 maxBytesPerFile)
     DropOutcome out;
     for (const QString& path : paths) {
         const QFileInfo info(path);
-        if (!info.isFile()) {
-            continue; // dropped a directory or something unreadable
+        if (info.isDir()) {
+            continue; // folders aren't attachable; nothing to report
+        }
+        if (!info.exists()) {
+            // Under a sandbox a dropped path outside the exported dirs (e.g. /tmp,
+            // external drives) is simply not visible here — report it so the drop
+            // does not fail silently.
+            qCWarning(lcWeb) << "drop: cannot access" << path << "(missing or outside sandbox)";
+            out.unreadable << info.fileName();
+            continue;
         }
         if (info.size() > maxBytesPerFile) {
-            qCWarning(lcWeb) << "drop: skipping" << info.fileName() << "(" << info.size() << "bytes > cap)";
-            out.skipped << info.fileName();
+            qCWarning(lcWeb) << "drop: skipping" << path << "(" << info.size() << "bytes > cap)";
+            out.tooLarge << info.fileName();
             continue;
         }
         QFile file(path);
         if (!file.open(QIODevice::ReadOnly)) {
-            out.skipped << info.fileName();
+            qCWarning(lcWeb) << "drop: cannot read" << path << file.errorString();
+            out.unreadable << info.fileName();
             continue;
         }
         const QByteArray bytes = file.readAll();

--- a/src/web/file_drop.h
+++ b/src/web/file_drop.h
@@ -13,8 +13,10 @@ namespace whatsie::web {
 
 struct DropOutcome
 {
-    QJsonArray files;    ///< [{name, type, b64}] for files within the cap
-    QStringList skipped; ///< names skipped (too big / unreadable)
+    QJsonArray files;       ///< [{name, type, b64}] for files within the cap
+    QStringList tooLarge;   ///< names skipped for exceeding the size cap
+    QStringList unreadable; ///< names that could not be accessed (missing path /
+                            ///< sandbox confinement / permission denied)
     qint64 totalBytes = 0;
 };
 

--- a/src/web/scripts/file-drop.js
+++ b/src/web/scripts/file-drop.js
@@ -11,6 +11,84 @@
 (function () {
     'use strict';
     var api = window.__whatsie || {};
+
+    // We intercept the drag in the widget layer (so the drop works on Wayland /
+    // Flatpak, where Chromium's native drop can't read the paths), which means
+    // WhatsApp Web never sees the dragover and never shows its own drop overlay.
+    // Draw our own so the target is as obvious as it is in a browser.
+    var HINT_ID = '__whatsie_drop_hint';
+    window.__whatsieDropHint = function (show) {
+        try {
+            var el = document.getElementById(HINT_ID);
+            if (show) {
+                if (!document.querySelector('#main')) {
+                    return; // no chat open: nothing to attach to, so no drop zone
+                }
+                if (!el) {
+                    el = document.createElement('div');
+                    el.id = HINT_ID;
+                    el.textContent = 'Drop files to send';
+                    var s = el.style;
+                    s.position = 'fixed';
+                    s.inset = '0';
+                    s.zIndex = '2147483646';
+                    s.display = 'flex';
+                    s.alignItems = 'center';
+                    s.justifyContent = 'center';
+                    s.font = '600 24px Segoe UI, Helvetica, Arial, sans-serif';
+                    s.color = '#fff';
+                    s.background = 'rgba(11,20,26,0.55)';
+                    s.border = '3px dashed rgba(255,255,255,0.7)';
+                    s.boxSizing = 'border-box';
+                    s.pointerEvents = 'none'; // never intercept the drag/drop itself
+                    document.body.appendChild(el);
+                }
+            } else if (el) {
+                el.remove();
+            }
+        } catch (e) {
+            api.report && api.report('drop-hint', e);
+        }
+    };
+
+    // A transient toast for drops that could not be attached (e.g. a file the
+    // sandbox can't read), so the failure is never silent.
+    window.__whatsieDropNotice = function (msg) {
+        try {
+            if (!msg) {
+                return;
+            }
+            var t = document.createElement('div');
+            t.textContent = msg;
+            var s = t.style;
+            s.position = 'fixed';
+            s.left = '50%';
+            s.bottom = '84px';
+            s.transform = 'translateX(-50%)';
+            s.zIndex = '2147483647';
+            s.maxWidth = '78%';
+            s.padding = '12px 18px';
+            s.borderRadius = '8px';
+            s.background = 'rgba(30,30,30,0.96)';
+            s.color = '#fff';
+            s.font = '500 14px Segoe UI, Helvetica, Arial, sans-serif';
+            s.lineHeight = '1.4';
+            s.textAlign = 'center';
+            s.boxShadow = '0 4px 16px rgba(0,0,0,0.4)';
+            s.pointerEvents = 'none';
+            document.body.appendChild(t);
+            setTimeout(function () {
+                t.style.transition = 'opacity .4s';
+                t.style.opacity = '0';
+            }, 4600);
+            setTimeout(function () {
+                t.remove();
+            }, 5100);
+        } catch (e) {
+            api.report && api.report('drop-notice', e);
+        }
+    };
+
     window.__whatsieDropFiles = function (files) {
         try {
             if (!files || !files.length) {

--- a/src/web/web_view.cpp
+++ b/src/web/web_view.cpp
@@ -4,6 +4,7 @@
 #include "core/theme/theme_service.h"
 #include "core/unread_badge.h"
 #include "core/zoom_policy.h"
+#include "platform/platform_info.h"
 #include "web/bridge.h"
 #include "web/clipboard_fix.h"
 #include "web/error_page.h"
@@ -23,6 +24,7 @@
 #include <QDropEvent>
 #include <QFont>
 #include <QFutureWatcher>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QKeyEvent>
 #include <QMenu>
@@ -277,6 +279,10 @@ bool WebView::maybeHandleDrop(QObject* watched, QEvent* event)
 {
     Q_UNUSED(watched)
     const QEvent::Type t = event->type();
+    if (t == QEvent::DragLeave) {
+        hideDropHintSoon();
+        return false;
+    }
     if (t != QEvent::DragEnter && t != QEvent::DragMove && t != QEvent::Drop) {
         return false;
     }
@@ -295,15 +301,45 @@ bool WebView::maybeHandleDrop(QObject* watched, QEvent* event)
         return false;
     }
     if (t == QEvent::Drop) {
+        setDropHint(false);
         drop->setDropAction(Qt::CopyAction);
         drop->accept();
         handleFileDrop(paths);
     } else {
+        setDropHint(true);
         auto* move = static_cast<QDragMoveEvent*>(event);
         move->setDropAction(Qt::CopyAction);
         move->accept();
     }
     return true;
+}
+
+void WebView::setDropHint(bool on)
+{
+    if (m_dropHintHide != nullptr) {
+        m_dropHintHide->stop(); // any real activity cancels a pending hide
+    }
+    if (on == m_dropHintOn) {
+        return;
+    }
+    m_dropHintOn = on;
+    m_page->runJavaScript(u"window.__whatsieDropHint && window.__whatsieDropHint(%1)"_s.arg(
+                              on ? u"true"_s : u"false"_s),
+                          QWebEngineScript::MainWorld);
+}
+
+void WebView::hideDropHintSoon()
+{
+    if (!m_dropHintOn) {
+        return;
+    }
+    if (m_dropHintHide == nullptr) {
+        m_dropHintHide = new QTimer(this);
+        m_dropHintHide->setSingleShot(true);
+        m_dropHintHide->setInterval(80);
+        connect(m_dropHintHide, &QTimer::timeout, this, [this] { setDropHint(false); });
+    }
+    m_dropHintHide->start();
 }
 
 void WebView::handleFileDrop(const QStringList& paths)
@@ -313,21 +349,46 @@ void WebView::handleFileDrop(const QStringList& paths)
     connect(watcher, &QFutureWatcher<DropOutcome>::finished, this, [this, watcher] {
         const DropOutcome outcome = watcher->result();
         watcher->deleteLater();
-        if (!outcome.skipped.isEmpty()) {
-            qCWarning(lcWeb) << "drop skipped:" << outcome.skipped;
+        if (!outcome.files.isEmpty()) {
+            // A JSON array is valid JavaScript (base64/strings are properly
+            // escaped), so pass it straight as the call argument.
+            const QString arrayLiteral =
+                QString::fromUtf8(QJsonDocument(outcome.files).toJson(QJsonDocument::Compact));
+            m_page->runJavaScript(
+                u"window.__whatsieDropFiles && window.__whatsieDropFiles(%1)"_s.arg(arrayLiteral),
+                QWebEngineScript::MainWorld);
         }
-        if (outcome.files.isEmpty()) {
-            return;
+        const QString notice = dropFailureNotice(outcome);
+        if (!notice.isEmpty()) {
+            const QString arg =
+                QString::fromUtf8(QJsonDocument(QJsonArray{notice}).toJson(QJsonDocument::Compact));
+            m_page->runJavaScript(
+                u"window.__whatsieDropNotice && window.__whatsieDropNotice(%1[0])"_s.arg(arg),
+                QWebEngineScript::MainWorld);
         }
-        // A JSON array is valid JavaScript (base64/strings are properly escaped),
-        // so pass it straight as the call argument.
-        const QString arrayLiteral =
-            QString::fromUtf8(QJsonDocument(outcome.files).toJson(QJsonDocument::Compact));
-        m_page->runJavaScript(
-            u"window.__whatsieDropFiles && window.__whatsieDropFiles(%1)"_s.arg(arrayLiteral),
-            QWebEngineScript::MainWorld);
     });
     watcher->setFuture(QtConcurrent::run([paths] { return buildDropPayload(paths, kMaxDropBytesPerFile); }));
+}
+
+QString WebView::dropFailureNotice(const DropOutcome& outcome) const
+{
+    QStringList parts;
+    if (!outcome.unreadable.isEmpty()) {
+        if (platform::isSandboxed()) {
+            parts << tr("Couldn't attach %n file(s). In this sandboxed build files must live "
+                        "in a shared folder such as Downloads or Pictures — items in /tmp or "
+                        "other locations can't be read.",
+                        nullptr, static_cast<int>(outcome.unreadable.size()));
+        } else {
+            parts << tr("Couldn't read %n dropped file(s).", nullptr,
+                        static_cast<int>(outcome.unreadable.size()));
+        }
+    }
+    if (!outcome.tooLarge.isEmpty()) {
+        parts << tr("%n file(s) skipped — larger than the 64 MB limit.", nullptr,
+                    static_cast<int>(outcome.tooLarge.size()));
+    }
+    return parts.join(u" "_s);
 }
 
 void WebView::applyBlurLive()

--- a/src/web/web_view.h
+++ b/src/web/web_view.h
@@ -21,6 +21,7 @@ namespace whatsie::web {
 class PermissionController;
 class WebPage;
 class WebProfile;
+struct DropOutcome;
 
 /// The widget that shows WhatsApp Web. Owns the profile and page; exposes
 /// only what the UI layer needs (zoom mode, unread count, chat links, crash
@@ -91,6 +92,9 @@ private:
     void handleProxyAuth(QAuthenticator* authenticator, const QString& proxyHost);
     bool maybeHandleDrop(class QObject* watched, class QEvent* event);
     void handleFileDrop(const QStringList& paths);
+    void setDropHint(bool on);
+    void hideDropHintSoon();
+    [[nodiscard]] QString dropFailureNotice(const DropOutcome& outcome) const;
 
     core::Settings& m_settings;
     core::ThemeService& m_theme;
@@ -101,6 +105,11 @@ private:
     core::ConnectionWatchdogPolicy m_watchdog;
     class QTimer* m_watchdogTimer = nullptr;
     QElapsedTimer m_clock;
+    // Debounced hide for the drag-and-drop hint overlay: DragLeave can fire
+    // spuriously between Chromium's nested widgets, so hide on a short delay
+    // that any further DragMove cancels.
+    class QTimer* m_dropHintHide = nullptr;
+    bool m_dropHintOn = false;
     bool m_maximizedMode = false;
     int m_unread = 0;
     // Current custom error page (if shown), remembered so it can be re-rendered

--- a/tests/tst_web_scripts.cpp
+++ b/tests/tst_web_scripts.cpp
@@ -120,8 +120,9 @@ private Q_SLOTS:
 
         const auto outcome = whatsie::web::buildDropPayload(
             {ok, big, dir.filePath(u"adir"_s), dir.filePath(u"missing"_s)}, 1024);
-        QCOMPARE(outcome.files.size(), 1); // big skipped (cap), dir + missing ignored
-        QCOMPARE(outcome.skipped, QStringList{u"big.bin"_s});
+        QCOMPARE(outcome.files.size(), 1); // dir ignored
+        QCOMPARE(outcome.tooLarge, QStringList{u"big.bin"_s});   // over the cap
+        QCOMPARE(outcome.unreadable, QStringList{u"missing"_s}); // not visible / gone
         const QJsonObject f = outcome.files.first().toObject();
         QCOMPARE(f.value(u"name"_s).toString(), u"photo.png"_s);
         QCOMPARE(f.value(u"type"_s).toString(), u"image/png"_s);


### PR DESCRIPTION
Three small fixes from recent reports.

### Tray tooltip (#348)
The system-tray tooltip read "WhatsApp"; it now reads "Whatsie".

### Diagnostics: CPU architecture
The bug-report host line now includes `arch: <x86_64|arm64|…>` (`QSysInfo::currentCpuArchitecture()`), which helps triage arch-specific reports.

### Drag-and-drop robustness + drop hint (#349)
Root cause: dropping a file the sandbox can't read — e.g. from `/tmp`, which under Flatpak is a private tmpfs, not the host's — failed **silently**. `buildDropPayload` skipped files it couldn't stat and the view just returned: no toast, no log.

- Split the skip reasons into **too-large** vs **unreadable**, and log the actual failing paths for diagnostics.
- Show a transient in-page **notice** when a drop can't attach, with sandbox-aware wording pointing at shared folders (Downloads/Pictures) — no more silent failures. (This is inherent to sandboxed DND: drag-and-drop isn't portalized, so an app can only read dropped paths already exposed via `--filesystem=`. Same limit as Flatpak Firefox/Chrome.)
- Because the drag is intercepted in the widget layer (so the drop works on Wayland/Flatpak where Chromium's native drop can't read paths), WhatsApp Web never shows its own drop overlay. We now draw our own **"Drop files to send"** hint on drag-over, with a debounced hide.

### Testing
- `buildDropPayload` unit test updated for the new `tooLarge`/`unreadable` split; all 24 tests pass.
- Verified end to end on a native build: overlay shows/hides cleanly on drag-over; a `chmod 000` file (and a faked `FLATPAK_ID`) produces the failure toast via the real code path; a normal file still opens the media editor.

Closes #348
Closes #349