### PR TITLE
fix(gpu): recover from the NVIDIA/Wayland black screen (software fallback) + 6.0.4

### DIFF
--- a/src/core/graphics_fallback.cpp
+++ b/src/core/graphics_fallback.cpp
@@ -26,6 +26,13 @@ bool isGraphicsInitFailure(const QString& message)
     return false;
 }
 
+bool isGbmVulkanFallback(const QString& message)
+{
+    // Chromium/ozone emits this on the NVIDIA driver under Wayland when it cannot
+    // allocate GBM buffers; the Vulkan fallback then renders the page black.
+    return message.contains(QLatin1StringView("GBM is not supported"), Qt::CaseInsensitive);
+}
+
 bool shouldRetryUnderXcb(QLatin1StringView platformName, bool alreadyRetried, bool failureSeen)
 {
     return failureSeen && !alreadyRetried && platformName == QLatin1StringView("wayland");

--- a/src/core/graphics_fallback.h
+++ b/src/core/graphics_fallback.h
@@ -11,6 +11,13 @@ namespace whatsie::core {
 /// initialize (EGL/GLX/OpenGL/RHI). Matched by substring, case-insensitively.
 [[nodiscard]] bool isGraphicsInitFailure(const QString& message);
 
+/// True for the Chromium log line emitted on NVIDIA/Wayland when GBM buffers are
+/// unavailable and it falls back to Vulkan rendering — which paints the web view
+/// black while the GPU process stays healthy (issue #351). Not a hard init
+/// failure, so detected separately; on Wayland it warrants one retry under
+/// XWayland, where the NVIDIA driver renders correctly.
+[[nodiscard]] bool isGbmVulkanFallback(const QString& message);
+
 /// Relaunch under XCB only on Wayland, only once, and only if a graphics
 /// failure was actually observed.
 [[nodiscard]] bool shouldRetryUnderXcb(QLatin1StringView platformName, bool alreadyRetried, bool failureSeen);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,12 +53,19 @@ void applyInterfaceScaleEnv()
 // FEATURES S20: watch the log stream for a graphics-backend init failure so we
 // can fall back from a broken Wayland RHI to XCB, once.
 std::atomic<bool> g_graphicsFailed{false};
+// NVIDIA/Wayland renders the web view black via the GBM→Vulkan fallback while the
+// GPU process stays healthy, so no init failure or crash fires — XWayland fixes
+// it and keeps GPU acceleration (issue #351).
+std::atomic<bool> g_gpuBlackScreen{false};
 QtMessageHandler g_previousHandler = nullptr;
 
 void graphicsWatchHandler(QtMsgType type, const QMessageLogContext& context, const QString& message)
 {
     if (whatsie::core::isGraphicsInitFailure(message)) {
         g_graphicsFailed.store(true);
+    }
+    if (whatsie::core::isGbmVulkanFallback(message)) {
+        g_gpuBlackScreen.store(true);
     }
     if (g_previousHandler != nullptr) {
         g_previousHandler(type, context, message);
@@ -196,7 +203,7 @@ int main(int argc, char* argv[])
     if (!retried && QGuiApplication::platformName() == QLatin1StringView("wayland")) {
         QTimer::singleShot(3000, &window, [&app] {
             if (whatsie::core::shouldRetryUnderXcb(QLatin1StringView("wayland"), false,
-                                                   g_graphicsFailed.load())) {
+                                                   g_graphicsFailed.load() || g_gpuBlackScreen.load())) {
                 relaunchUnderXcb(app);
             }
         });

--- a/tests/tst_graphics_fallback.cpp
+++ b/tests/tst_graphics_fallback.cpp
@@ -31,6 +31,26 @@ private Q_SLOTS:
         QCOMPARE(isGraphicsInitFailure(message), isFailure);
     }
 
+    void detectsGbmVulkanFallback_data()
+    {
+        QTest::addColumn<QString>("message");
+        QTest::addColumn<bool>("isFallback");
+        QTest::newRow("nvidia gbm") << u"GBM is not supported with the current configuration. "
+                                       "Fallback to Vulkan rendering in Chromium."_s
+                                    << true;
+        QTest::newRow("case") << u"gbm IS NOT SUPPORTED"_s << true;
+        QTest::newRow("normal gpu log") << u"Using GPU rasterization"_s << false;
+        QTest::newRow("real failure") << u"eglInitialize failed"_s << false;
+        QTest::newRow("empty") << QString() << false;
+    }
+
+    void detectsGbmVulkanFallback()
+    {
+        QFETCH(QString, message);
+        QFETCH(bool, isFallback);
+        QCOMPARE(isGbmVulkanFallback(message), isFallback);
+    }
+
     void retriesOnlyOnWaylandOnceAfterFailure()
     {
         QCOMPARE(shouldRetryUnderXcb("wayland"_L1, false, true), true);


### PR DESCRIPTION
Fixes the black-screen-on-startup report in #351, and bumps to **6.0.4** (this is the release that also carries the spell-check fixes merged via #354).

### Root cause
On the NVIDIA driver under **Wayland**, Chromium can't allocate **GBM** buffers and falls back to **Vulkan** rendering, which paints the web view black while the GPU process stays healthy. Tray/menus work because they're Qt-drawn, not the Chromium surface. Reported on Bazzite (`bazzite-nvidia-open`, RTX 4070 SUPER, KDE Plasma Wayland). Log: `GBM is not supported with the current configuration. Fallback to Vulkan rendering in Chromium.`

None of the existing safety nets fired: no context-loss storm, no graphics-init failure, no crash-probe strike (`GPU stable; probe cleared`).

### Fix
Detect the `GBM is not supported` line and, under the **Automatic** hardware-acceleration setting, fall back to **software rendering** once — reusing the existing `--disable-gpu` relaunch (`relaunchForGpuFallback`) and its one-shot user notice. Persisting the fallback (`gpuAutoDisabled`) stops it recurring; forced On/Off are left alone.

**Why software, not XWayland:** the reporter confirmed that forcing XWayland (`QT_QPA_PLATFORM=xcb`) **failed to start the app at all** on their setup, while turning hardware acceleration off worked. So the automatic recovery uses software rendering; the XCB retry stays reserved for hard graphics-init failures (FEATURES S20).

- New pure detector `isGbmVulkanFallback()` (+ unit tests).
- `graphicsWatchHandler` sets a `g_gpuBlackScreen` flag; the 3s Wayland timer routes it to the software fallback.

### Release
`chore(release): 6.0.4` — CMake version, metainfo entry (validated), debian changelog. **Merge #354 (spell check) first**, then this without `[skip ci]`; the combined `main` is then tagged `v6.0.4`.

### Testing
Build green; all 24 tests pass.