### PR TITLE
fix(spellcheck): sideloadable dictionaries + harden the dictionary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ Download the installer or portable build from the
 
 Windows 10/11, 64-bit; it bundles its own Qt runtime.
 
+## Spell check
+
+Whatsie bundles dictionaries for several languages (English, German, Spanish,
+French, Italian, Russian). Turn it on and pick a language in **Settings →
+Advanced → Spell check**.
+
+To add a language that isn't bundled, drop its Chromium `<code>.bdic` file into
+the dictionaries folder — the **Open folder…** button in that same settings
+section takes you straight there (then reopen the dialog to pick the language):
+
+- **Snap:** `~/snap/whatsie/current/.local/share/ktechpit/whatsie/qtwebengine_dictionaries/`
+- **Flatpak:** `~/.var/app/com.ktechpit.whatsie/data/ktechpit/whatsie/qtwebengine_dictionaries/`
+- **Other:** `~/.local/share/ktechpit/whatsie/qtwebengine_dictionaries/`
+
+`.bdic` is Chromium's compiled dictionary format. Convert a Hunspell `.dic`/`.aff`
+pair with the `qwebengine_convert_dict` tool that ships with Qt WebEngine, e.g.
+`qwebengine_convert_dict fr_FR.dic fr-FR.bdic`.
+
 ## Build from source
 
 Requires Qt **6.11** (the version shipped by the snap `kf6-core24` runtime and the Flathub

--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -187,12 +187,19 @@ void Application::applyChromiumFlags()
 
 void Application::configureDictionaries()
 {
-    // Point QtWebEngine at bundled .bdic spell-check dictionaries (FEATURES L1),
-    // unless the environment already sets it. Roots cover dev, /usr, snap and
-    // flatpak; findDictionariesPath returns the qtwebengine_dictionaries dir.
+    // Point QtWebEngine at bundled .bdic spell-check dictionaries (FEATURES L1).
+    // An expert may override the location, but only honour a pre-set path that
+    // actually holds dictionaries — a stale or empty value (e.g. one a user
+    // exported while experimenting) must not silently disable spell check (#353).
     if (qEnvironmentVariableIsSet("QTWEBENGINE_DICTIONARIES_PATH")) {
-        return;
+        const QString preset = qEnvironmentVariable("QTWEBENGINE_DICTIONARIES_PATH");
+        if (!core::availableDictionaries(preset).isEmpty()) {
+            qCInfo(lcApp) << "spell-check dictionaries: using preset path" << preset;
+            return;
+        }
+        qCWarning(lcApp) << "ignoring QTWEBENGINE_DICTIONARIES_PATH (no .bdic in" << preset << ")";
     }
+    // Roots cover dev, /usr, snap and flatpak.
     QStringList roots;
     if (qEnvironmentVariableIsSet("SNAP")) {
         roots << qEnvironmentVariable("SNAP") + u"/usr/share/whatsie"_s;
@@ -200,10 +207,17 @@ void Application::configureDictionaries()
     const QString appDir = applicationDirPath();
     roots << QDir(appDir).filePath(u"../share/whatsie"_s) << appDir << u"/app/share/whatsie"_s
           << u"/usr/share/whatsie"_s;
-    const QString dir = core::findDictionariesPath(roots);
+    const QString bundled = core::findDictionariesPath(roots);
+
+    // Merge the bundled dictionaries with any the user has sideloaded into a
+    // single writable directory (issue #353) — QtWebEngine only searches one.
+    const QString userDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                            + u"/qtwebengine_dictionaries"_s;
+    const QString dir = core::prepareDictionaryDir(bundled, userDir);
     if (!dir.isEmpty()) {
         qputenv("QTWEBENGINE_DICTIONARIES_PATH", QDir(dir).absolutePath().toUtf8());
-        qCInfo(lcApp) << "spell-check dictionaries:" << dir;
+        qCInfo(lcApp) << "spell-check dictionaries:" << dir
+                      << "(drop your own .bdic files here to add languages)";
     } else {
         qCInfo(lcApp) << "no bundled spell-check dictionaries found; relying on defaults";
     }

--- a/src/core/spellcheck.cpp
+++ b/src/core/spellcheck.cpp
@@ -1,6 +1,7 @@
 #include "core/spellcheck.h"
 
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QLocale>
 
@@ -45,6 +46,41 @@ QStringList availableDictionaries(const QString& dictionaryDir)
     }
     names.sort();
     return names;
+}
+
+QString prepareDictionaryDir(const QString& bundledDir, const QString& userDir)
+{
+    if (userDir.isEmpty()) {
+        return bundledDir; // nowhere writable — fall back to the bundled set
+    }
+    QDir dir(userDir);
+    if (!dir.exists() && !QDir().mkpath(userDir)) {
+        return bundledDir; // could not create the writable directory
+    }
+    // Drop every bundled symlink we previously created (valid or now-stale, e.g.
+    // a gone snap revision) so the set is rebuilt fresh; a user's own real .bdic
+    // is left untouched.
+    const auto present = dir.entryInfoList({u"*.bdic"_s}, QDir::Files | QDir::System);
+    for (const QFileInfo& entry : present) {
+        if (entry.isSymLink()) {
+            QFile::remove(entry.absoluteFilePath());
+        }
+    }
+    // Link the current bundled dictionaries in beside the user's own, never
+    // clobbering a real file the user dropped with the same name.
+    if (!bundledDir.isEmpty()) {
+        const auto bundled = QDir(bundledDir).entryInfoList({u"*.bdic"_s}, QDir::Files, QDir::Name);
+        for (const QFileInfo& entry : bundled) {
+            const QString dest = dir.filePath(entry.fileName());
+            if (QFileInfo::exists(dest)) {
+                continue; // a user override with the same name — keep theirs
+            }
+            if (!QFile::link(entry.absoluteFilePath(), dest)) {
+                QFile::copy(entry.absoluteFilePath(), dest); // symlinks unavailable
+            }
+        }
+    }
+    return userDir;
 }
 
 QString resolveDictionary(const QString& want, const QStringList& available)

--- a/src/core/spellcheck.h
+++ b/src/core/spellcheck.h
@@ -20,6 +20,15 @@ namespace whatsie::core {
 /// sorted. Empty when the directory is missing or has none.
 [[nodiscard]] QStringList availableDictionaries(const QString& dictionaryDir);
 
+/// Prepares a single writable directory holding both the bundled dictionaries
+/// and any the user has sideloaded (issue #353). QtWebEngine only ever searches
+/// one directory, so the bundled `.bdic` files in `bundledDir` are symlinked
+/// (copied where symlinks are unavailable) into `userDir` beside the user's own
+/// files. Bundled symlinks are refreshed each call so they never go stale across
+/// an app update; a real file the user dropped is never overwritten. Returns the
+/// directory to point QtWebEngine at: `userDir` when usable, else `bundledDir`.
+[[nodiscard]] QString prepareDictionaryDir(const QString& bundledDir, const QString& userDir);
+
 /// Picks the installed dictionary to actually use for `want` (a name from
 /// dictionaryNameForLocale, e.g. "en-IN"): the exact one if present, else the
 /// bare language ("en"), else the first same-language variant ("en-GB"), else

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -468,6 +468,24 @@ QWidget* SettingsDialog::buildAdvancedTab()
         row->addRow(tr("Language:"), m_spellLanguage);
         spellLayout->addLayout(row);
     }
+
+    // Let users add languages we don't bundle by dropping .bdic files into the
+    // writable dictionaries folder QtWebEngine reads (issue #353).
+    const QString dictDir = qEnvironmentVariable("QTWEBENGINE_DICTIONARIES_PATH");
+    if (!dictDir.isEmpty()) {
+        auto* addRow = new QHBoxLayout;
+        auto* hint = new QLabel(tr("Missing a language? Drop its .bdic dictionary file into the "
+                                   "dictionaries folder, then reopen this dialog."),
+                                spellBox);
+        hint->setWordWrap(true);
+        hint->setStyleSheet(u"color: palette(placeholder-text);"_s);
+        auto* openDir = new QPushButton(tr("Open folder…"), spellBox);
+        connect(openDir, &QPushButton::clicked, this,
+                [dictDir] { QDesktopServices::openUrl(QUrl::fromLocalFile(dictDir)); });
+        addRow->addWidget(hint, 1);
+        addRow->addWidget(openDir, 0, Qt::AlignTop);
+        spellLayout->addLayout(addRow);
+    }
     outer->addWidget(spellBox);
 
     outer->addWidget(buildNetworkGroup());

--- a/tests/tst_spellcheck.cpp
+++ b/tests/tst_spellcheck.cpp
@@ -2,6 +2,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QFileInfo>
 #include <QLocale>
 #include <QTemporaryDir>
 #include <QTest>
@@ -71,6 +72,52 @@ private Q_SLOTS:
         QVERIFY(resolveDictionary(u"en-US"_s, {}).isEmpty());    // nothing installed
         QCOMPARE(resolveDictionary(u"en"_s, QStringList{u"en"_s, u"en-US"_s}),
                  u"en"_s); // bare language present
+    }
+
+    void mergesBundledAndSideloadedDictionaries()
+    {
+        QTemporaryDir bundled;
+        QTemporaryDir user;
+        QVERIFY(bundled.isValid() && user.isValid());
+        auto touch = [](const QString& path) {
+            QFile f(path);
+            QVERIFY(f.open(QIODevice::WriteOnly));
+            f.write("x");
+        };
+        touch(bundled.filePath(u"en-US.bdic"_s)); // bundled
+        touch(bundled.filePath(u"de-DE.bdic"_s)); // bundled
+        touch(user.filePath(u"pl-PL.bdic"_s));    // user sideloaded a new language
+        touch(user.filePath(u"en-US.bdic"_s));    // user override of a bundled one
+
+        const QString dir = prepareDictionaryDir(bundled.path(), user.path());
+        QCOMPARE(dir, user.path());
+        // All languages visible in the one directory QtWebEngine searches.
+        QCOMPARE(availableDictionaries(dir), (QStringList{u"de-DE"_s, u"en-US"_s, u"pl-PL"_s}));
+        // Bundled linked in; the user's own real files are never clobbered.
+        QVERIFY(QFileInfo(user.filePath(u"de-DE.bdic"_s)).isSymLink());
+        QVERIFY(!QFileInfo(user.filePath(u"en-US.bdic"_s)).isSymLink());
+        QVERIFY(!QFileInfo(user.filePath(u"pl-PL.bdic"_s)).isSymLink());
+    }
+
+    void refreshesStaleBundledSymlinks()
+    {
+        QTemporaryDir bundled;
+        QTemporaryDir user;
+        QVERIFY(bundled.isValid() && user.isValid());
+        // A leftover link to a bundled dict from a previous (gone) install path.
+        QVERIFY(QFile::link(u"/nonexistent/old/fr-FR.bdic"_s, user.filePath(u"fr-FR.bdic"_s)));
+        QFile f(bundled.filePath(u"it-IT.bdic"_s));
+        QVERIFY(f.open(QIODevice::WriteOnly));
+
+        const QString dir = prepareDictionaryDir(bundled.path(), user.path());
+        QCOMPARE(availableDictionaries(dir), (QStringList{u"it-IT"_s})); // stale gone, current linked
+    }
+
+    void fallsBackToBundledWhenNoWritableDir()
+    {
+        QTemporaryDir bundled;
+        QVERIFY(bundled.isValid());
+        QCOMPARE(prepareDictionaryDir(bundled.path(), QString()), bundled.path());
     }
 };
 


### PR DESCRIPTION
Addresses #353 (spell checker doesn't work). This covers the whatsie-side fixes; the Flatpak French bundling is a separate manifest change on the Flathub repo.

### Two root causes
1. **A stale/empty `QTWEBENGINE_DICTIONARIES_PATH` disabled spell check.** `configureDictionaries` returned early whenever the env var was set — so the value the reporter exported while experimenting (`/usr/share/hunspell-bdic`, no `.bdic`) made whatsie skip its own bundled dictionaries. Now a preset path is honoured **only when it actually contains `.bdic` files**.
2. **No supported way to add a language the build doesn't bundle.** QtWebEngine only ever searches one directory, so we now point it at a **writable per-user** `qtwebengine_dictionaries` dir and **symlink the bundled `.bdic` files in beside** anything the user drops there. Links are refreshed each launch (so they never go stale across an update, e.g. a new snap revision), and a real file the user added is never overwritten.

### UX / docs
- **Settings → Advanced → Spell check** gains an **"Open folder…"** button that opens that directory, plus a one-line hint.
- **README** documents the per-format folder paths and how to get a `.bdic` (convert a Hunspell `.dic`/`.aff` with `qwebengine_convert_dict`).

### Tests
New `tst_spellcheck` cases: bundled+sideloaded merge (user override preserved), stale-symlink refresh, and fallback when there's no writable dir. All 24 tests pass.

### Follow-up (separate, Flathub repo)
The Flatpak build currently bundles only what `org.kde.Sdk`'s `/usr/share/hunspell` happens to ship (en_US, no French), which is why `fr-FR` fails there. I'll add a `hunspell-dictionaries` module sourced from `LibreOffice/dictionaries` (the common Flathub pattern) so Flatpak ships the same language set as the snap.