### PR TITLE
fix(gpu): NVIDIA/Wayland black screen — software fallback (supersedes #352) + 6.0.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(whatsie
-    VERSION 6.0.3
+    VERSION 6.0.4
     DESCRIPTION "WhatsApp Web desktop client built with Qt WebEngine"
     HOMEPAGE_URL "https://github.com/keshavbhatt/whatsie"
     LANGUAGES CXX

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+whatsie (6.0.4) unstable; urgency=medium
+
+  * Spell check: fix dictionaries silently failing to load; allow adding
+    languages from Settings → Advanced → Spell check.
+  * NVIDIA/Wayland: fall back to software rendering instead of a black screen.
+
+ -- Keshav Bhatt <keshavnrj@gmail.com>  Mon, 07 Sep 2026 12:00:00 +0530
+
 whatsie (6.0.3) unstable; urgency=medium
 
   * Drag-and-drop: show a drop hint and report files that can't be attached

--- a/dist/linux/com.ktechpit.whatsie.metainfo.xml
+++ b/dist/linux/com.ktechpit.whatsie.metainfo.xml
@@ -102,6 +102,15 @@
   </content_rating>
 
   <releases>
+    <release version="6.0.4" date="2026-09-07">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Spell check no longer silently fails to load its dictionaries, and you can now add languages yourself from Settings → Advanced → Spell check</li>
+          <li>On NVIDIA graphics under Wayland, Whatsie falls back to software rendering automatically instead of showing a black screen</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.0.3" date="2026-09-05">
       <description>
         <p>Fixes and small improvements:</p>

--- a/src/core/graphics_fallback.h
+++ b/src/core/graphics_fallback.h
@@ -14,8 +14,8 @@ namespace whatsie::core {
 /// True for the Chromium log line emitted on NVIDIA/Wayland when GBM buffers are
 /// unavailable and it falls back to Vulkan rendering — which paints the web view
 /// black while the GPU process stays healthy (issue #351). Not a hard init
-/// failure, so detected separately; on Wayland it warrants one retry under
-/// XWayland, where the NVIDIA driver renders correctly.
+/// failure, so detected separately; it warrants a one-shot fall back to software
+/// rendering (switching to XWayland can fail to start on these setups).
 [[nodiscard]] bool isGbmVulkanFallback(const QString& message);
 
 /// Relaunch under XCB only on Wayland, only once, and only if a graphics

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,8 +54,8 @@ void applyInterfaceScaleEnv()
 // can fall back from a broken Wayland RHI to XCB, once.
 std::atomic<bool> g_graphicsFailed{false};
 // NVIDIA/Wayland renders the web view black via the GBM→Vulkan fallback while the
-// GPU process stays healthy, so no init failure or crash fires — XWayland fixes
-// it and keeps GPU acceleration (issue #351).
+// GPU process stays healthy, so no init failure or crash fires — fall back to
+// software rendering, which recovers it (XWayland can fail to start; issue #351).
 std::atomic<bool> g_gpuBlackScreen{false};
 QtMessageHandler g_previousHandler = nullptr;
 
@@ -198,12 +198,24 @@ int main(int argc, char* argv[])
     // the crash probe so the next start is not treated as a GPU crash.
     QTimer::singleShot(20000, &app, [&app] { app.markGpuStable(); });
 
-    // Give the GPU stack time to fail, then fall back to XCB if it did (once).
-    const bool retried = qEnvironmentVariableIsSet("WHATSIE_XCB_RETRY");
-    if (!retried && QGuiApplication::platformName() == QLatin1StringView("wayland")) {
+    // Give the GPU/graphics stack time to fail, then self-heal (once).
+    if (QGuiApplication::platformName() == QLatin1StringView("wayland")) {
         QTimer::singleShot(3000, &window, [&app] {
-            if (whatsie::core::shouldRetryUnderXcb(QLatin1StringView("wayland"), false,
-                                                   g_graphicsFailed.load() || g_gpuBlackScreen.load())) {
+            // A silent black web view on NVIDIA/Wayland (GBM unavailable → Vulkan
+            // fallback) is recovered by software rendering: switching to XWayland
+            // can fail to start there entirely (issue #351). Only under Automatic
+            // and only once — persisting the fallback stops it recurring.
+            if (g_gpuBlackScreen.load()
+                && app.settings().hardwareAcceleration() == whatsie::core::HardwareAcceleration::Auto
+                && !app.settings().gpuAutoDisabled()) {
+                relaunchForGpuFallback(app);
+                return;
+            }
+            // A hard graphics-backend init failure on Wayland is retried under XCB
+            // once (FEATURES S20).
+            const bool retried = qEnvironmentVariableIsSet("WHATSIE_XCB_RETRY");
+            if (whatsie::core::shouldRetryUnderXcb(QLatin1StringView("wayland"), retried,
+                                                   g_graphicsFailed.load())) {
                 relaunchUnderXcb(app);
             }
         });


### PR DESCRIPTION
Follow-up to #352, which merged with the wrong recovery strategy. Also bumps to **6.0.4** (the release that ships this together with the spell-check fixes already on `main` via #354).

### Why
#352 relaunched under **XWayland** on the GBM→Vulkan black-screen signal. The reporter then tested it and found **XWayland fails to launch the app at all** on their NVIDIA/Wayland setup, while **Hardware acceleration → Off (software) worked** ([#351 comment](https://github.com/keshavbhatt/whatsie/issues/351)).

### Change
Route the `GBM is not supported` signal to the existing **software-rendering** fallback (`relaunchForGpuFallback` → `--disable-gpu` + one-shot notice) instead of `relaunchUnderXcb`:

- Only under the **Automatic** hardware-acceleration setting, and only once (`gpuAutoDisabled` persists it, so no relaunch loop; forced On/Off are left alone).
- The **XCB retry stays** for genuine graphics-init failures (FEATURES S20) — unchanged.

The `isGbmVulkanFallback` detector and `g_gpuBlackScreen` flag (added in #352) are reused; only the routing changes.

### Release
`chore(release): 6.0.4` — CMake version, metainfo entry (validated), debian changelog, covering both this and the spell-check fixes now on `main`.

### Testing
Build green; all 24 tests pass. Merge without `[skip ci]`; `main` is then tagged `v6.0.4`.