### PR TITLE
fix(snap): match the snapd-exported desktop id on Wayland (#357)

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -34,6 +34,21 @@ Application::Application(int& argc, char** argv)
     setOrganizationName(QString::fromLatin1(version::kOrganizationName));
     setOrganizationDomain(QString::fromLatin1(version::kOrganizationDomain));
     setDesktopFileName(QString::fromLatin1(version::kDesktopId));
+    // Under a snap, snapd exports the desktop file as "<snap>_<app>.desktop", not
+    // the reverse-DNS id — so a Wayland shell (e.g. GNOME) can't match the window
+    // to it and shows the raw app id with a generic icon (issue #357). Set the app
+    // id to the exported name so it resolves. (Flatpak exports the reverse-DNS
+    // name, which already matches, and native installs use it too.)
+    if (qEnvironmentVariableIsSet("SNAP")) {
+        QByteArray snap = qgetenv("SNAP_INSTANCE_NAME");
+        if (snap.isEmpty()) {
+            snap = qgetenv("SNAP_NAME");
+        }
+        if (!snap.isEmpty()) {
+            setDesktopFileName(
+                u"%1_%2"_s.arg(QString::fromUtf8(snap), QString::fromLatin1(version::kApplicationName)));
+        }
+    }
     setWindowIcon(QIcon(u":/icons/whatsie.svg"_s));
     setQuitOnLastWindowClosed(false); // the tray keeps us alive; MainWindow decides
 


### PR DESCRIPTION
Fixes #357 — under the **snap** on GNOME/Wayland, Whatsie shows as `com.ktechpit.whatsie` with a generic icon instead of "Whatsie" and its real icon. (The reporter confirmed **flatpak is fine**.)

### Cause
A Wayland shell matches a window to a `.desktop` file by the window's **app-id**. Whatsie sets the app-id to the reverse-DNS `com.ktechpit.whatsie` (via `setDesktopFileName`). But snapd **exports** the desktop file as `whatsie_whatsie.desktop` (`<snap>_<app>`), so nothing matches the reverse-DNS id → GNOME falls back to showing the raw id and a generic icon. Flatpak exports `com.ktechpit.whatsie.desktop`, which matches — hence it works there.

### Fix
When running inside a snap (`$SNAP` set), set the app-id to the exported name `${SNAP_INSTANCE_NAME}_whatsie`. Flatpak and native installs keep the reverse-DNS id (which matches there), so they're unaffected.

### Testing
Build green; all 24 tests pass. Needs a real snap install on a Wayland session to confirm end-to-end (I can't set the window app-id meaningfully off-snap here).