### PR TITLE
fix(tray): centre and size the monochrome tray glyph (#356)

### DIFF
--- a/src/core/unread_badge.cpp
+++ b/src/core/unread_badge.cpp
@@ -107,6 +107,42 @@ QImage monochromeIcon(const QImage& glyph)
     return out;
 }
 
+QImage fitGlyphToIcon(const QImage& glyph, int size, qreal fill)
+{
+    if (glyph.isNull() || size <= 0) {
+        return glyph;
+    }
+    const QImage src = glyph.convertToFormat(QImage::Format_ARGB32_Premultiplied);
+    int minX = src.width();
+    int minY = src.height();
+    int maxX = -1;
+    int maxY = -1;
+    for (int y = 0; y < src.height(); ++y) {
+        const auto* line = reinterpret_cast<const QRgb*>(src.scanLine(y));
+        for (int x = 0; x < src.width(); ++x) {
+            if (qAlpha(line[x]) != 0) {
+                minX = std::min(minX, x);
+                maxX = std::max(maxX, x);
+                minY = std::min(minY, y);
+                maxY = std::max(maxY, y);
+            }
+        }
+    }
+    if (maxX < minX || maxY < minY) {
+        return glyph; // nothing opaque to fit
+    }
+    const QImage cropped = src.copy(QRect(minX, minY, maxX - minX + 1, maxY - minY + 1));
+    const int box = std::max(1, qRound(size * std::clamp(fill, qreal(0.1), qreal(1.0))));
+    const QImage scaled = cropped.scaled(box, box, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
+    QImage out(size, size, QImage::Format_ARGB32_Premultiplied);
+    out.fill(Qt::transparent);
+    QPainter painter(&out);
+    painter.drawImage(QPoint((size - scaled.width()) / 2, (size - scaled.height()) / 2), scaled);
+    painter.end();
+    return out;
+}
+
 QImage tintImage(const QImage& image, const QColor& color)
 {
     if (image.isNull()) {

--- a/src/core/unread_badge.h
+++ b/src/core/unread_badge.h
@@ -27,4 +27,9 @@ namespace whatsie::core {
 /// colour is not knowable and is independent of the app theme.
 [[nodiscard]] QImage monochromeIcon(const QImage& glyph);
 
+/// Trims the transparent margin around `glyph`, then centres it in a `size`×`size`
+/// square filling `fill` (0..1) of the box. A symbolic glyph with uneven internal
+/// padding otherwise renders small and off-centre next to other tray icons (#356).
+[[nodiscard]] QImage fitGlyphToIcon(const QImage& glyph, int size, qreal fill);
+
 } // namespace whatsie::core

--- a/src/ui/tray_controller.cpp
+++ b/src/ui/tray_controller.cpp
@@ -142,8 +142,11 @@ void TrayController::reloadBaseImage()
         // a dark panel. Panel colour is independent of the app theme, so render a
         // white glyph with a thin dark halo: visible on dark panels (white fill)
         // and light ones (dark outline).
-        const QImage glyph = QIcon(u":/icons/whatsie-symbolic.svg"_s).pixmap(QSize(128, 128)).toImage();
-        m_baseImage = core::monochromeIcon(glyph);
+        // Render large, then trim/centre/scale so the glyph fills the icon like
+        // the neighbouring panel icons rather than sitting small and off-centre
+        // inside its SVG padding (#356), before the white-fill + halo pass.
+        const QImage glyph = QIcon(u":/icons/whatsie-symbolic.svg"_s).pixmap(QSize(256, 256)).toImage();
+        m_baseImage = core::monochromeIcon(core::fitGlyphToIcon(glyph, 128, 0.9));
     } else {
         m_baseImage = QImage(u":/icons/hicolor/128x128/apps/com.ktechpit.whatsie.png"_s);
     }

--- a/tests/tst_unread_badge.cpp
+++ b/tests/tst_unread_badge.cpp
@@ -4,6 +4,8 @@
 #include <QPainter>
 #include <QTest>
 
+#include <algorithm>
+
 using namespace Qt::StringLiterals;
 using namespace whatsie::core;
 
@@ -123,6 +125,44 @@ private Q_SLOTS:
     }
 
     void monochromeIconNullPassesThrough() { QVERIFY(monochromeIcon(QImage()).isNull()); }
+
+    void fitGlyphCentresAndScales()
+    {
+        // A 200x200 canvas with a 60x60 opaque block anchored top-left, like a
+        // symbolic SVG whose glyph sits small and off-centre in its padding.
+        QImage glyph(200, 200, QImage::Format_ARGB32_Premultiplied);
+        glyph.fill(Qt::transparent);
+        {
+            QPainter p(&glyph);
+            p.fillRect(QRect(0, 0, 60, 60), Qt::black);
+        }
+        const QImage out = fitGlyphToIcon(glyph, 128, 0.9);
+        QCOMPARE(out.size(), QSize(128, 128));
+
+        int minX = 128;
+        int minY = 128;
+        int maxX = -1;
+        int maxY = -1;
+        for (int y = 0; y < out.height(); ++y) {
+            const auto* line = reinterpret_cast<const QRgb*>(out.constScanLine(y));
+            for (int x = 0; x < out.width(); ++x) {
+                if (qAlpha(line[x]) != 0) {
+                    minX = std::min(minX, x);
+                    maxX = std::max(maxX, x);
+                    minY = std::min(minY, y);
+                    maxY = std::max(maxY, y);
+                }
+            }
+        }
+        // Scaled to ~0.9*128 ≈ 115 px (square block keeps its aspect ratio).
+        QVERIFY(maxX - minX + 1 >= 112 && maxX - minX + 1 <= 118);
+        QVERIFY(maxY - minY + 1 >= 112 && maxY - minY + 1 <= 118);
+        // Centred: margins on opposite sides are equal to within a pixel.
+        QVERIFY(qAbs(minX - (127 - maxX)) <= 1);
+        QVERIFY(qAbs(minY - (127 - maxY)) <= 1);
+    }
+
+    void fitGlyphNullPassesThrough() { QVERIFY(fitGlyphToIcon(QImage(), 128, 0.9).isNull()); }
 
 private:
     static QImage solid(int size, const QColor& color)


### PR DESCRIPTION
Fixes the monochrome tray icon looking smaller and off-centre than neighbouring panel icons (#356).

### Cause
`whatsie-symbolic.svg`'s glyph sits in the **top-left** of its 64×64 canvas, filling only ~84% and leaving a ~16% gap on the bottom-right. `reloadBaseImage()` rendered it as-is, so in the tray it read both small and shifted next to the shell's own (centred, ~90%-filling) symbolic icons.

### Fix
New pure helper `fitGlyphToIcon(glyph, size, fill)` trims the glyph to its opaque bounds, then centres and scales it to a consistent fill (0.9) — so it no longer depends on the SVG's internal placement. Wired into the symbolic tray path before the existing white-fill + halo pass; the coloured-icon path is unchanged.

(The halo/recolour question — Telegram-style themed symbolic icons the shell recolours — is deferred; this addresses the size/centring the reporter flagged.)

### Testing
New `tst_unread_badge` case asserts the glyph ends up centred (equal margins) and scaled to ~0.9 of the box. Build green; all 24 tests pass. Verified visually that the glyph is centred and larger.