### PR TITLE
feat(tray): unread count on the launcher/taskbar (Unity LauncherEntry) — #122

### DIFF
--- a/src/platform/CMakeLists.txt
+++ b/src/platform/CMakeLists.txt
@@ -7,6 +7,8 @@ qt_add_library(whatsie_platform STATIC
     crash_handler.h
     file_manager.h
     gpu_stderr_watch.h
+    launcher_badge.cpp
+    launcher_badge.h
     logging.cpp
     logging.h
     notifier_factory.cpp
@@ -30,6 +32,7 @@ if(LINUX)
         linux/dbus_image.h
         linux/file_manager_dbus.cpp
         linux/gpu_stderr_watch.cpp
+        linux/launcher_badge_dbus.cpp
         linux/freedesktop_notifier.cpp
         linux/freedesktop_notifier.h
         linux/portal_notifier.cpp
@@ -41,6 +44,7 @@ else()
         crash_handler_generic.cpp
         file_manager_generic.cpp
         gpu_stderr_watch_generic.cpp
+        launcher_badge_generic.cpp
     )
     if(WIN32)
         target_sources(whatsie_platform PRIVATE windows/autostart_registry.cpp)

--- a/src/platform/launcher_badge.cpp
+++ b/src/platform/launcher_badge.cpp
@@ -1,0 +1,15 @@
+#include "platform/launcher_badge.h"
+
+using namespace Qt::StringLiterals;
+
+namespace whatsie::platform {
+
+QString launcherEntryUri(const QString& desktopId)
+{
+    if (desktopId.isEmpty()) {
+        return {};
+    }
+    return u"application://%1.desktop"_s.arg(desktopId);
+}
+
+} // namespace whatsie::platform

--- a/src/platform/launcher_badge.h
+++ b/src/platform/launcher_badge.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QString>
+
+// Launcher/dock unread badge (FEATURES T8, issue #122). On Linux the count is
+// broadcast over the com.canonical.Unity.LauncherEntry D-Bus protocol, which KDE
+// Plasma's task manager, GNOME's Dash-to-Dock and others paint on the app's
+// launcher button. A no-op where the protocol is unavailable.
+namespace whatsie::platform {
+
+/// The LauncherEntry app URI for a desktop id (the .desktop basename, no suffix):
+/// "com.ktechpit.whatsie" → "application://com.ktechpit.whatsie.desktop". Empty in,
+/// empty out. Pure; unit-tested.
+[[nodiscard]] QString launcherEntryUri(const QString& desktopId);
+
+/// Shows `count` as an unread badge on the app's launcher/taskbar button.
+/// `desktopId` is the .desktop basename (pass QGuiApplication::desktopFileName()).
+/// count <= 0 hides the badge. No-op on platforms without the protocol.
+void setLauncherCount(const QString& desktopId, int count);
+
+} // namespace whatsie::platform

--- a/src/platform/launcher_badge_generic.cpp
+++ b/src/platform/launcher_badge_generic.cpp
@@ -1,0 +1,9 @@
+#include "platform/launcher_badge.h"
+
+namespace whatsie::platform {
+
+// No launcher-badge protocol on this platform (a Windows taskbar overlay could
+// slot in here later — FEATURES T8).
+void setLauncherCount(const QString& /*desktopId*/, int /*count*/) {}
+
+} // namespace whatsie::platform

--- a/src/platform/linux/launcher_badge_dbus.cpp
+++ b/src/platform/linux/launcher_badge_dbus.cpp
@@ -1,0 +1,31 @@
+#include "platform/launcher_badge.h"
+
+#include <QDBusConnection>
+#include <QDBusMessage>
+#include <QVariantMap>
+
+#include <algorithm>
+
+using namespace Qt::StringLiterals;
+
+namespace whatsie::platform {
+
+void setLauncherCount(const QString& desktopId, int count)
+{
+    const QString uri = launcherEntryUri(desktopId);
+    if (uri.isEmpty()) {
+        return;
+    }
+    // A plain session-bus signal — no libunity dependency. Listeners match on the
+    // app URI in the payload, so the object path is only for namespacing.
+    QDBusMessage signal = QDBusMessage::createSignal(u"/com/ktechpit/whatsie/LauncherEntry"_s,
+                                                     u"com.canonical.Unity.LauncherEntry"_s,
+                                                     u"Update"_s);
+    QVariantMap props;
+    props.insert(u"count"_s, static_cast<qlonglong>(std::max(0, count)));
+    props.insert(u"count-visible"_s, count > 0);
+    signal << uri << props;
+    QDBusConnection::sessionBus().send(signal);
+}
+
+} // namespace whatsie::platform

--- a/src/ui/main_window.cpp
+++ b/src/ui/main_window.cpp
@@ -8,6 +8,7 @@
 #include "core/theme/theme_service.h"
 #include "core/zoom_policy.h"
 #include "platform/autostart.h"
+#include "platform/launcher_badge.h"
 #include "ui/about_dialog.h"
 #include "ui/actions.h"
 #include "ui/downloads_hub.h"
@@ -647,6 +648,10 @@ void MainWindow::syncAutostart()
 void MainWindow::handleUnread(int count)
 {
     m_tray->setUnreadCount(count); // unread shows on the tray; the window keeps the colour logo
+    // Also surface it on the launcher/taskbar button where the desktop supports it
+    // (FEATURES T8, issue #122). The app id matches the desktop file GNOME/KDE use,
+    // including the snapd-exported name under a snap.
+    platform::setLauncherCount(QGuiApplication::desktopFileName(), count);
 }
 
 void MainWindow::handleRenderProcessGaveUp()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ whatsie_add_test(tst_storage_and_flags   tst_storage_and_flags.cpp   whatsie_cor
 whatsie_add_test(tst_identicon           tst_identicon.cpp           whatsie_core GUI)
 whatsie_add_test(tst_notification_service tst_notification_service.cpp whatsie_core GUI)
 # platform
+whatsie_add_test(tst_launcher_badge      tst_launcher_badge.cpp      whatsie_platform)
 if(LINUX)
     whatsie_add_test(tst_freedesktop_notifier tst_freedesktop_notifier.cpp whatsie_platform GUI)
 endif()

--- a/tests/tst_launcher_badge.cpp
+++ b/tests/tst_launcher_badge.cpp
@@ -1,0 +1,26 @@
+#include "platform/launcher_badge.h"
+
+#include <QTest>
+
+using namespace Qt::StringLiterals;
+using namespace whatsie::platform;
+
+class TestLauncherBadge : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void buildsAppUri()
+    {
+        QCOMPARE(launcherEntryUri(u"com.ktechpit.whatsie"_s),
+                 u"application://com.ktechpit.whatsie.desktop"_s);
+        // Snap-exported id (issue #357) round-trips the same way.
+        QCOMPARE(launcherEntryUri(u"whatsie_whatsie"_s),
+                 u"application://whatsie_whatsie.desktop"_s);
+    }
+
+    void emptyIdGivesEmptyUri() { QVERIFY(launcherEntryUri(QString()).isEmpty()); }
+};
+
+QTEST_MAIN(TestLauncherBadge)
+#include "tst_launcher_badge.moc"


### PR DESCRIPTION
Implements the long-standing request to show the unread count on the taskbar/dock, like Discord and Telegram (#122). This is roadmap **T8**; the maintained fork whatly already does it.

### How
Broadcasts the unread total over the **`com.canonical.Unity.LauncherEntry`** D-Bus protocol — a plain session-bus signal (**no libunity**) that KDE Plasma's task manager, GNOME's Dash-to-Dock and others read and paint as a badge on the launcher button. Desktops without the protocol simply ignore it.

- New platform backend: pure `launcherEntryUri()` + `setLauncherCount()` with a Linux D-Bus impl and a no-op generic impl (a Windows taskbar overlay could slot in here later).
- Hooked into `MainWindow::handleUnread`, right beside the existing tray badge, so it reuses the count already parsed from the page title.
- The app URI uses `QGuiApplication::desktopFileName()`, so it matches the desktop file the shell actually knows — including the snapd-exported `whatsie_whatsie.desktop` name from #357.

### Testing
Unit test covers the URI builder (incl. the snap-exported id). Build green; all 25 tests pass. The D-Bus emission mirrors whatly's proven implementation; the actual badge painting needs a live KDE/GNOME session to confirm end-to-end.

### Notes
- No setting — it's always on (harmless where unsupported), matching the tray badge and whatly. Easy to gate behind a toggle later if wanted.