### PR TITLE
feat(advanced): render at the display's refresh rate (#221)

### DIFF
--- a/src/app/application.cpp
+++ b/src/app/application.cpp
@@ -180,7 +180,7 @@ void Application::applyChromiumFlags()
     evaluateGpuStability();
     const QString existing = qEnvironmentVariable("QTWEBENGINE_CHROMIUM_FLAGS");
     QStringList ours = core::chromiumFlags(m_settings->hardwareAcceleration(), m_settings->gpuAutoDisabled(),
-                                           m_settings->jsMemoryLimitMb());
+                                           m_settings->jsMemoryLimitMb(), m_settings->uncapFrameRate());
     // In a snap we pass --no-sandbox here (isolation comes from snap confinement,
     // ADR-008) rather than hard-coding it in the snap's environment: — that let
     // it override the user's QTWEBENGINE_CHROMIUM_FLAGS and blocked the expert

--- a/src/core/chromium_flags.cpp
+++ b/src/core/chromium_flags.cpp
@@ -21,7 +21,8 @@ bool useSoftwareGpu(HardwareAcceleration acceleration, bool autoDisabled)
     return autoDisabled;
 }
 
-QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled, int jsMemoryLimitMb)
+QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled, int jsMemoryLimitMb,
+                          bool uncapFrameRate)
 {
     QStringList flags{
         // Nothing here is a chat client's business.
@@ -75,6 +76,11 @@ QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisable
         flags << u"--js-flags=--max-old-space-size=%1"_s.arg(jsMemoryLimitMb);
     } else {
         flags << u"--js-flags=--optimize-for-size"_s;
+    }
+    // Opt-in: let the page paint at the display's refresh rate instead of
+    // Chromium's 60 FPS default (#221). Costs more GPU/CPU, hence off by default.
+    if (uncapFrameRate) {
+        flags << u"--disable-frame-rate-limit"_s;
     }
     return flags;
 }

--- a/src/core/chromium_flags.h
+++ b/src/core/chromium_flags.h
@@ -17,7 +17,7 @@ enum class HardwareAcceleration;
 /// (see useSoftwareGpu) it also enables SwiftShader so WhatsApp calls keep a
 /// software WebGL context instead of a blank remote video (ADR-032).
 [[nodiscard]] QStringList chromiumFlags(HardwareAcceleration acceleration, bool gpuAutoDisabled = false,
-                                        int jsMemoryLimitMb = 0);
+                                        int jsMemoryLimitMb = 0, bool uncapFrameRate = false);
 
 /// Merges `userFlags` (existing env var content) with ours, deduplicated.
 [[nodiscard]] QString mergeChromiumFlags(const QString& userFlags, const QStringList& ours);

--- a/src/core/settings/settings.cpp
+++ b/src/core/settings/settings.cpp
@@ -39,6 +39,7 @@ constexpr bool kDefaultAskWhereToSave = false;
 constexpr bool kDefaultShowDownloadsOnStart = true;
 constexpr HardwareAcceleration kDefaultHardwareAcceleration = HardwareAcceleration::Auto;
 constexpr int kDefaultJsMemoryLimitMb = 0;
+constexpr bool kDefaultUncapFrameRate = false;
 constexpr bool kDefaultWebrtcPublicOnly = false;
 constexpr bool kDefaultSpellCheckEnabled = true;
 constexpr bool kDefaultLockOnStart = false;
@@ -454,6 +455,18 @@ void Settings::setJsMemoryLimitMb(int mb)
     }
     m_store->setValue(keys::kJsMemoryLimitMb, clamped);
     Q_EMIT jsMemoryLimitMbChanged(clamped);
+}
+
+bool Settings::uncapFrameRate() const
+{
+    return boolValue(keys::kUncapFrameRate, kDefaultUncapFrameRate);
+}
+
+void Settings::setUncapFrameRate(bool enabled)
+{
+    if (storeBool(keys::kUncapFrameRate, kDefaultUncapFrameRate, enabled)) {
+        Q_EMIT uncapFrameRateChanged(enabled);
+    }
 }
 
 bool Settings::webrtcPublicInterfacesOnly() const

--- a/src/core/settings/settings.h
+++ b/src/core/settings/settings.h
@@ -167,6 +167,10 @@ public:
     void setJsMemoryLimitMb(int mb);
     static constexpr int kMinJsMemoryLimitMb = 256;
     static constexpr int kMaxJsMemoryLimitMb = 8192;
+    /// Drop Chromium's 60 FPS cap so the page renders at the display's refresh
+    /// rate (#221). Costs more GPU/CPU. Applied to the Chromium flags at startup.
+    [[nodiscard]] bool uncapFrameRate() const;
+    void setUncapFrameRate(bool enabled);
     /// FEATURES P2: force WebRTC onto public interfaces only (privacy; can break
     /// LAN calls). Default off.
     [[nodiscard]] bool webrtcPublicInterfacesOnly() const;
@@ -252,6 +256,7 @@ Q_SIGNALS:
     void showDownloadsOnStartChanged(bool show);
     void hardwareAccelerationChanged(whatsie::core::HardwareAcceleration mode);
     void jsMemoryLimitMbChanged(int mb);
+    void uncapFrameRateChanged(bool enabled);
 
 private:
     [[nodiscard]] bool boolValue(QLatin1StringView key, bool def) const;

--- a/src/core/settings/settings_keys.h
+++ b/src/core/settings/settings_keys.h
@@ -77,6 +77,8 @@ inline constexpr QLatin1StringView kGpuProbeStrikes{"advanced/gpuProbeStrikes"};
 inline constexpr QLatin1StringView kGpuFallbackNotice{"advanced/gpuFallbackNotice"};
 // V8 JavaScript heap cap in MB; 0 = automatic. Bounds WhatsApp Web's memory.
 inline constexpr QLatin1StringView kJsMemoryLimitMb{"advanced/jsMemoryLimitMb"};
+// Drop Chromium's 60 FPS cap so the page renders at the display's refresh rate.
+inline constexpr QLatin1StringView kUncapFrameRate{"advanced/uncapFrameRate"};
 
 // proxy/ (password is deliberately NOT a key — never persisted)
 inline constexpr QLatin1StringView kProxyMode{"proxy/mode"};

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1326,6 +1326,14 @@ Ihr Sperr-Passcode bleibt erhalten. Einige Änderungen werden nach einem Neustar
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Laden Sie WhatsApp neu (F5), damit die Proxy-Änderungen wirksam werden. Das Passwort wird niemals auf der Festplatte gespeichert.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Mit der Bildwiederholrate des Displays rendern</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Entfernt das 60-FPS-Limit von Chromium, sodass Bildlauf und Animationen mit der Bildwiederholrate Ihres Monitors laufen. Benötigt mehr GPU und CPU. Wird nach einem Neustart von Whatsie wirksam.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -1326,6 +1326,14 @@ Se conserva tu código de bloqueo. Algunos cambios se aplican tras reiniciar Wha
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Recarga WhatsApp (F5) para que los cambios del proxy surtan efecto. La contraseña nunca se guarda en el disco.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Renderizar a la frecuencia de actualización de la pantalla</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Elimina el límite de 60 FPS de Chromium para que el desplazamiento y las animaciones se ejecuten a la frecuencia de actualización de tu monitor. Usa más GPU y CPU. Se aplica tras reiniciar Whatsie.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -1326,6 +1326,14 @@ Votre code de verrouillage est conservé. Certains changements prennent effet ap
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Rechargez WhatsApp (F5) pour que les changements de proxy prennent effet. Le mot de passe n'est jamais enregistré sur le disque.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Afficher à la fréquence de rafraîchissement de l'écran</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Supprime la limite de 60 FPS de Chromium afin que le défilement et les animations s'exécutent à la fréquence de rafraîchissement de votre écran. Consomme plus de GPU et de CPU. Prend effet après le redémarrage de Whatsie.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -1326,6 +1326,14 @@ Il codice di blocco viene mantenuto. Alcune modifiche hanno effetto dopo il riav
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Ricarica WhatsApp (F5) affinché le modifiche al proxy abbiano effetto. La password non viene mai salvata su disco.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Renderizza alla frequenza di aggiornamento dello schermo</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Rimuove il limite di 60 FPS di Chromium così lo scorrimento e le animazioni vanno alla frequenza di aggiornamento del monitor. Usa più GPU e CPU. Ha effetto dopo il riavvio di Whatsie.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/i18n/pt_BR.ts
+++ b/src/i18n/pt_BR.ts
@@ -1326,6 +1326,14 @@ Sua senha de bloqueio é mantida. Algumas alterações têm efeito depois que vo
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Recarregue o WhatsApp (F5) para que as alterações do proxy tenham efeito. A senha nunca é salva no disco.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Renderizar na taxa de atualização da tela</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Remove o limite de 60 FPS do Chromium para que a rolagem e as animações rodem na taxa de atualização do seu monitor. Usa mais GPU e CPU. Tem efeito após reiniciar o Whatsie.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -1326,6 +1326,14 @@ Your lock passcode is kept. Some changes take effect after you restart Whatsie.<
         <source>Reload WhatsApp (F5) for proxy changes to take effect. The password is never saved to disk.</source>
         <translation>Обновите WhatsApp (F5), чтобы изменения прокси вступили в силу. Пароль никогда не сохраняется на диск.</translation>
     </message>
+    <message>
+        <source>Render at the display's refresh rate</source>
+        <translation>Отрисовывать с частотой обновления дисплея</translation>
+    </message>
+    <message>
+        <source>Removes Chromium's 60 FPS cap so scrolling and animations run at your monitor's refresh rate. Uses more GPU and CPU. Takes effect after restarting Whatsie.</source>
+        <translation>Снимает ограничение Chromium в 60 кадров/с, чтобы прокрутка и анимация шли с частотой обновления вашего монитора. Потребляет больше ресурсов GPU и CPU. Вступает в силу после перезапуска Whatsie.</translation>
+    </message>
 </context>
 <context>
     <name>whatsie::ui::ShortcutsDialog</name>

--- a/src/ui/settings_dialog.cpp
+++ b/src/ui/settings_dialog.cpp
@@ -569,6 +569,13 @@ QWidget* SettingsDialog::buildAdvancedTab()
     connect(m_webrtcPublicOnly, &QCheckBox::toggled, this,
             [this](bool on) { m_settings.setWebrtcPublicInterfacesOnly(on); });
     aform->addRow(QString(), m_webrtcPublicOnly);
+    m_uncapFrameRate = new QCheckBox(tr("Render at the display's refresh rate"), advBox);
+    m_uncapFrameRate->setToolTip(tr("Removes Chromium's 60 FPS cap so scrolling and animations run at "
+                                    "your monitor's refresh rate. Uses more GPU and CPU. Takes effect "
+                                    "after restarting Whatsie."));
+    connect(m_uncapFrameRate, &QCheckBox::toggled, this,
+            [this](bool on) { m_settings.setUncapFrameRate(on); });
+    aform->addRow(QString(), m_uncapFrameRate);
     av->addLayout(aform);
 
     auto* hwNote =
@@ -793,6 +800,7 @@ void SettingsDialog::loadValues()
     m_hardwareAcceleration->setCurrentIndex(
         m_hardwareAcceleration->findData(static_cast<int>(m_settings.hardwareAcceleration())));
     m_jsMemoryLimit->setValue(m_settings.jsMemoryLimitMb());
+    m_uncapFrameRate->setChecked(m_settings.uncapFrameRate());
     if (m_interfaceLanguage != nullptr) {
         const QSignalBlocker blocker(m_interfaceLanguage);
         const int i = m_interfaceLanguage->findData(m_settings.interfaceLanguage());

--- a/src/ui/settings_dialog.h
+++ b/src/ui/settings_dialog.h
@@ -95,6 +95,7 @@ private:
     QSpinBox* m_notificationTimeout = nullptr;
     QComboBox* m_hardwareAcceleration = nullptr;
     QSpinBox* m_jsMemoryLimit = nullptr;
+    QCheckBox* m_uncapFrameRate = nullptr;
     QCheckBox* m_spellCheck = nullptr;
     QListWidget* m_spellLanguages = nullptr;
     QLabel* m_lockStatus = nullptr;

--- a/tests/tst_storage_and_flags.cpp
+++ b/tests/tst_storage_and_flags.cpp
@@ -120,6 +120,15 @@ private Q_SLOTS:
         QVERIFY(!capped.contains(u"--js-flags=--optimize-for-size"_s));
     }
 
+    void uncapFrameRateFlag()
+    {
+        // Off by default (#221); the flag appears only when explicitly enabled.
+        QVERIFY(!chromiumFlags(HardwareAcceleration::Auto, false, 0, false)
+                     .contains(u"--disable-frame-rate-limit"_s));
+        QVERIFY(chromiumFlags(HardwareAcceleration::Auto, false, 0, true)
+                    .contains(u"--disable-frame-rate-limit"_s));
+    }
+
     void userFlagsAreKeptAndDeduplicated()
     {
         const QString merged =


### PR DESCRIPTION
Adds a **Settings → Advanced → "Render at the display's refresh rate"** toggle that drops Chromium's 60 FPS cap so scrolling and animations run at the monitor's refresh rate (120/144 Hz, etc.).

### How
- New `advanced/uncapFrameRate` setting (bool, **off by default**), wired through `core::chromiumFlags()` which appends `--disable-frame-rate-limit` when enabled — the same path `hardwareAcceleration` already uses. Applied at startup via `Application::applyChromiumFlags()`.
- Checkbox in the Advanced tab with a tooltip noting it **uses more GPU and CPU** and takes effect after a restart.

### Why a toggle
The expert escape hatch already worked — `QTWEBENGINE_CHROMIUM_FLAGS=--disable-frame-rate-limit` is merged in by `mergeChromiumFlags()` — but env vars are a non-starter for most users and awkward to set inside snap/flatpak confinement (exactly what the reporter hit). This just makes it discoverable. Default-off keeps it away from the CPU-usage concerns in #190.

### Testing
- New unit test `uncapFrameRateFlag`: the flag is absent by default and present only when enabled. All 25 tests pass.
- Interface strings translated for all shipped languages (de, es, fr, it, pt_BR, ru); `lrelease` reports 274/274 finished, verified at runtime.

Closes #221