### PR TITLE
chore(release): 6.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(whatsie
-    VERSION 6.0.4
+    VERSION 6.1.0
     DESCRIPTION "WhatsApp Web desktop client built with Qt WebEngine"
     HOMEPAGE_URL "https://github.com/keshavbhatt/whatsie"
     LANGUAGES CXX

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+whatsie (6.1.0) unstable; urgency=medium
+
+  * Interface translations: German, Spanish, French, Italian, Portuguese
+    (Brazil) and Russian, selectable in Settings → General.
+  * Unread count now shown as a launcher/taskbar badge.
+  * Spell check can use multiple languages at once (Settings → Advanced).
+  * New Settings → Advanced option to render at the display's refresh rate.
+  * Tray: centre and size the monochrome glyph correctly.
+  * Wayland: match the snap-exported desktop id so the app groups correctly.
+
+ -- Keshav Bhatt <keshavnrj@gmail.com>  Wed, 09 Sep 2026 12:00:00 +0530
+
 whatsie (6.0.4) unstable; urgency=medium
 
   * Spell check: fix dictionaries silently failing to load; allow adding

--- a/dist/linux/com.ktechpit.whatsie.metainfo.xml
+++ b/dist/linux/com.ktechpit.whatsie.metainfo.xml
@@ -102,6 +102,22 @@
   </content_rating>
 
   <releases>
+    <release version="6.1.0" date="2026-09-09">
+      <description>
+        <p>New features:</p>
+        <ul>
+          <li>Whatsie's interface can now be translated — German, Spanish, French, Italian, Portuguese (Brazil) and Russian are included; pick one in Settings → General, or leave it on Automatic to follow your system</li>
+          <li>The unread message count now appears as a badge on the taskbar or dock launcher</li>
+          <li>Spell check can use several languages at the same time (Settings → Advanced)</li>
+          <li>New option to render at your display's refresh rate instead of the 60 FPS cap (Settings → Advanced)</li>
+        </ul>
+        <p>Fixes:</p>
+        <ul>
+          <li>The monochrome system-tray icon is now centred and sized correctly</li>
+          <li>On Wayland the app uses the correct desktop id, so it groups properly in the dock and task switcher</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.0.4" date="2026-09-07">
       <description>
         <p>Fixes:</p>


### PR DESCRIPTION
Release 6.1.0. Bumps `CMakeLists.txt`, adds the AppStream `<release>` entry (validated) and a `debian/changelog` entry.

Rolls up since v6.0.4:
- Interface translations + language picker (#363, #171)
- Launcher/taskbar unread badge (#360, #122)
- Multiple spell-check languages at once (#362, #132)
- Render at the display's refresh rate (#364, #221)
- Selectable spell-check dictionaries for packagers (#361, #61)
- Tray glyph centring/sizing (#359, #356)
- Wayland desktop-id match (#358, #357)

Merging this triggers the snap + Windows builds; the `v6.1.0` tag then triggers the AppImage/.deb bundles.